### PR TITLE
Worker job changes

### DIFF
--- a/lucky/supervisord.conf
+++ b/lucky/supervisord.conf
@@ -80,7 +80,7 @@ serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 
 [program:wp1-worker]
 ; In the docker-compose world, the redis host is just 'redis'
-command=/usr/local/bin/rq worker -u redis://redis update upload
+command=/usr/local/bin/python worker.py update upload
 ; process_num is required if you specify >1 numprocs
 process_name=%(process_num)s
 

--- a/lucky/worker.py
+++ b/lucky/worker.py
@@ -1,0 +1,14 @@
+import sys
+
+from redis import Redis
+from rq import Connection, Worker
+
+# Preload API so login is only done once
+import lucky.api
+
+conn = Redis(host='redis')
+with Connection(conn):
+    qs = sys.argv[1:] or ['default']
+
+    w = Worker(qs)
+    w.work()


### PR DESCRIPTION
This branch changes the way workers are set up so that they use a custom script (not a custom class) for doing the work. This custom script largely delegates to the rq `Worker` class. It is mainly provided so that the import of the api module and the connection to Wikipedia (logging in) can be done prefork, to avoid "too many login attempts in a row" errors with the API.

We also provide changes to enqueue-all to allow for only upload jobs to be queued.