### PR TITLE
Retry jobs

### DIFF
--- a/lucky/requirements.txt
+++ b/lucky/requirements.txt
@@ -2,6 +2,7 @@ attrs==18.2.0
 certifi==2018.11.29
 chardet==3.0.4
 Click==7.0
+croniter==0.3.30
 idna==2.8
 Jinja2==2.10.1
 MarkupSafe==1.1.1
@@ -11,10 +12,13 @@ mwparserfromhell==0.5.2
 nose==1.3.7
 oauthlib==2.1.0
 PyMySQL==0.9.3
+python-dateutil==2.8.0
 redis==3.3.6
 requests==2.21.0
 requests-oauthlib==1.0.0
 rq==1.1.0
+rq-retry==0.3.0
+rq-scheduler==0.9
 six==1.12.0
 supervisor==4.0.4
 urllib3==1.24.2

--- a/lucky/supervisord.conf
+++ b/lucky/supervisord.conf
@@ -92,6 +92,7 @@ numprocs=8
 directory=/usr/src/app
 
 redirect_stderr=true
+stdout_logfile=/tmp/%(program_name)s-%(process_num)s.log
 
 ; RQ requires the TERM signal to perform a warm shutdown. If RQ does not die
 ; within 10 seconds, supervisor will forcefully kill it

--- a/lucky/supervisord.conf
+++ b/lucky/supervisord.conf
@@ -99,3 +99,15 @@ stdout_logfile=/tmp/%(program_name)s-%(process_num)s.log
 stopsignal=TERM
 autostart=true
 autorestart=true
+
+
+; This is the scheduler worker that puts failed jobs back on the queues
+[program:rqscheduler]
+command=/usr/local/bin/rqscheduler --host redis
+
+directory=/usr/src/app
+redirect_stderr=true
+stdout_logfile=/tmp/%(program_name)s.log
+
+autostart=true
+autorestart=true

--- a/lucky/worker.py
+++ b/lucky/worker.py
@@ -12,7 +12,7 @@ with Connection(conn):
     qs = sys.argv[1:] or ['default']
 
     # Retry failed jobs after 30 seconds, then 180 seconds.
-    w = RetryWorker(qs, retry_config={'delays': [30,180]})
+    w = RetryWorker(qs, retry_config={'delays': [30,180], 'max_tries': 5})
     # Workaround for apparent bug in RetryWorker.
     w.failed_queue = Queue('failed', connection=conn)
     w.work()


### PR DESCRIPTION
Adds a dependency on `rq-retry` and `rq-scheduler` in order to retry failed jobs, first after 30 seconds, then after 3 minutes, up to 4 total retries (5 total attempts).