### PR TITLE
Configure db connections globally

### DIFF
--- a/lucky/lucky/logic/project.py
+++ b/lucky/lucky/logic/project.py
@@ -13,8 +13,8 @@ from lucky.models.wiki.page import Page
 from lucky.models.wp10.category import Category
 from lucky.models.wp10.project import Project
 from lucky.models.wp10.rating import Rating
-from lucky.wp10_db import connect as wp10_connect
-from lucky.wiki_db import connect as wiki_connect
+from lucky.wp10_db import connection as wp10db
+from lucky.wiki_db import connection as wikidb
 
 logger = logging.getLogger(__name__)
 
@@ -28,9 +28,6 @@ RE_INDICATOR = re.compile(b'([A-Za-z]+)[ _-]')
 
 
 def update_project_by_name(project_name):
-  wp10db = wp10_connect()
-  wikidb = wiki_connect()
-
   logging.basicConfig(level=logging.DEBUG)
   logging.getLogger('mwclient').setLevel(logging.CRITICAL)
   logging.getLogger('urllib3').setLevel(logging.CRITICAL)

--- a/lucky/lucky/tables.py
+++ b/lucky/lucky/tables.py
@@ -8,7 +8,7 @@ from lucky.conf import get_conf
 from lucky.constants import LIST_URL
 from lucky.models.wp10.category import Category
 from lucky.models.wp10.rating import Rating
-from lucky.wp10_db import connect as wp10_connect
+from lucky.wp10_db import connection as wp10db
 
 def commas(n):
   return "{:,d}".format(n)
@@ -79,6 +79,7 @@ def get_global_categories():
 
 
 def get_global_stats(wp10db):
+  wp10db.ping()
   with wp10db.cursor() as cursor:
     cursor.execute('''
       SELECT count(distinct a_article) as n,
@@ -94,6 +95,7 @@ def get_global_stats(wp10db):
 
 
 def get_project_stats(wp10db, project_name):
+  wp10db.ping()
   with wp10db.cursor() as cursor:
     cursor.execute('''
       SELECT count(r_article) as n, r_quality as q, r_importance as i,
@@ -105,6 +107,7 @@ def get_project_stats(wp10db, project_name):
 
 
 def db_project_categories(wp10db, project_name):
+  wp10db.ping()
   with wp10db.cursor() as cursor:
     cursor.execute('SELECT c_type, c_rating, c_ranking, c_category FROM ' +
                    Category.table_name + ' WHERE c_project = %s', (project_name,))
@@ -226,49 +229,34 @@ def generate_table_data(stats, categories, table_overrides=None):
 
 
 def generate_project_table_data(project_name, stats=None, categories=None):
-  wp10db = None
-  if stats is None or categories is None:
-    wp10db = wp10_connect()
+  if stats is None:
+    stats = get_project_stats(wp10db, project_name)
+    print(repr(stats))
 
-  try:
-    if stats is None:
-      stats = get_project_stats(wp10db, project_name)
-      print(repr(stats))
+  if categories is None:
+    categories = get_project_categories(wp10db, project_name)
 
-    if categories is None:
-      categories = get_project_categories(wp10db, project_name)
-
-    title = ('%s articles by quality and importance' %
-             project_name.decode('utf-8').replace('_', ' '))
-    return generate_table_data(stats, categories, {
-      'project': project_name,
-      'create_link': True,
-      'title': title,
-      'center_table': False,
-    })
-  finally:
-    if wp10db is not None:
-      wp10db.close()
+  title = ('%s articles by quality and importance' %
+           project_name.decode('utf-8').replace('_', ' '))
+  return generate_table_data(stats, categories, {
+    'project': project_name,
+    'create_link': True,
+    'title': title,
+    'center_table': False,
+  })
 
 
 def generate_global_table_data(stats=None):
-  wp10db = None
   if stats is None:
-    wp10db = wp10_connect()
-  try:
-    if stats is None:
-      stats = get_global_stats(wp10db)
-    categories = get_global_categories()
+    stats = get_global_stats(wp10db)
+  categories = get_global_categories()
 
-    return generate_table_data(stats, categories, {
-      'project': None,
-      'create_link': False, # Whether the values link to the web app.
-      'title': 'All rated articles by quality and importance',
-      'center_table': True,
-    })
-  finally:
-    if wp10db is not None:
-      wp10db.close()
+  return generate_table_data(stats, categories, {
+    'project': None,
+    'create_link': False, # Whether the values link to the web app.
+    'title': 'All rated articles by quality and importance',
+    'center_table': True,
+  })
 
 
 def upload_project_table(project_name, stats=None, categories=None):

--- a/lucky/lucky/wiki_db.py
+++ b/lucky/lucky/wiki_db.py
@@ -1,12 +1,14 @@
+import logging
 import os
 
 import pymysql
 import pymysql.cursors
 
-try:
-  from lucky.credentials import WIKI_CREDS
+logger = logging.getLogger(__name__)
 
-  def connect():
+def connect():
+  try:
+    from lucky.credentials import WIKI_CREDS
     kwargs = {
       'charset': None,
       'use_unicode': False,
@@ -14,9 +16,10 @@ try:
       **WIKI_CREDS
     }
     return pymysql.connect(**kwargs)
+  except ImportError:
+    # No creds, so return an empty connection. This will likely blow up any
+    # methods that require a connection.
+    logger.error('No db credentials found. Have you created credentials.py?')
+    return None
 
-except ImportError:
-  # No creds, so return an empty connect method that will blow up. This is only
-  # to satisfy imports.
-  def connect():
-    pass
+connection = connect()

--- a/lucky/lucky/wp10_db.py
+++ b/lucky/lucky/wp10_db.py
@@ -1,12 +1,14 @@
+import logging
 import os
 
 import pymysql
 import pymysql.cursors
 
-try:
-  from lucky.credentials import WP10_CREDS
+logger = logging.getLogger(__name__)
 
-  def connect():
+def connect():
+  try:
+    from lucky.credentials import WP10_CREDS
     kwargs = {
       'charset': None,
       'use_unicode': False,
@@ -14,9 +16,10 @@ try:
       **WP10_CREDS
     }
     return pymysql.connect(**kwargs)
-except ImportError:
-  # No creds, so return an empty connect method that will blow up. This is only
-  # to satisfy imports.
-  def connect():
-    pass
+  except ImportError:
+    # No creds, so return an empty connection. This will likely blow up any
+    # methods that require a connection.
+    logger.error('No db credentials found. Have you created credentials.py?')
+    return None
 
+connection = connect()

--- a/lucky/worker.py
+++ b/lucky/worker.py
@@ -4,8 +4,12 @@ from redis import Redis
 from rq import Connection, Queue
 from rq_retry import RetryWorker
 
-# Preload API so login is only done once
+# Preload API so login is only done once.
 import lucky.api
+
+# Preload connections to databases, prefork.
+import lucky.wp10_db
+import lucky.wiki_db
 
 conn = Redis(host='redis')
 with Connection(conn):


### PR DESCRIPTION
By creating a global variable in each database module (WIki replica db and WP1.0 db), we can connect to the databases "prefork" in the worker script, so all worker jobs will share a connection (instead of connecting to the database in each worker sub process).

As part of this, we add calls to wp10db.ping() which will check for a stale connection and reconnect.

This is a partial fix to #23.