### PR TITLE
Start of web Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,15 @@ services:
     depends_on:
       - redis
 
+  web:
+    image: wp1bot-web
+    container_name: wp1bot-web
+    links:
+      - redis
+    restart: always
+    depends_on:
+      - redis
+
   redis:
     image: redis
     container_name: wp1bot-redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,10 @@ services:
   web:
     image: wp1bot-web
     container_name: wp1bot-web
+    ports:
+      - 9181:9181
+    volumes:
+      - /data/wp1bot/rq-credentials.txt:/usr/src/app/rq-credentials.txt
     links:
       - redis
     restart: always

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.7
+
+# Meta
+LABEL maintainer="kiwix"
+
+# Python app
+WORKDIR /usr/src
+COPY lucky app
+RUN pip3 install -r app/requirements.txt
+
+# Start
+COPY docker/web/start.sh /usr/local/bin/start.sh
+CMD start.sh

--- a/docker/web/start.sh
+++ b/docker/web/start.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-USER=`head -n 1 app/rq-credentials.txt`
-PASS=`tail -n 1 app/rq-credentials.txt`
+USER=$(head -n 1 app/rq-credentials.txt)
+PASS=$(tail -n 1 app/rq-credentials.txt)
 
 rq-dashboard --username $USER --password $PASS -H redis

--- a/docker/web/start.sh
+++ b/docker/web/start.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+rq-dashboard --username wp10 --password g00db0t -H redis

--- a/docker/web/start.sh
+++ b/docker/web/start.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
-rq-dashboard --username wp10 --password g00db0t -H redis
+USER=`head -n 1 app/rq-credentials.txt`
+PASS=`tail -n 1 app/rq-credentials.txt`
+
+rq-dashboard --username $USER --password $PASS -H redis

--- a/lucky/requirements.txt
+++ b/lucky/requirements.txt
@@ -1,9 +1,12 @@
+arrow==0.14.5
 attrs==18.2.0
 certifi==2018.11.29
 chardet==3.0.4
 Click==7.0
 croniter==0.3.30
+Flask==1.1.1
 idna==2.8
+itsdangerous==1.1.0
 Jinja2==2.10.1
 MarkupSafe==1.1.1
 meld3==1.0.2
@@ -17,8 +20,10 @@ redis==3.3.6
 requests==2.21.0
 requests-oauthlib==1.0.0
 rq==1.1.0
+rq-dashboard==0.5.2
 rq-retry==0.3.0
 rq-scheduler==0.9
 six==1.12.0
 supervisor==4.0.4
 urllib3==1.24.2
+Werkzeug==0.15.5

--- a/web.Dockerfile
+++ b/web.Dockerfile
@@ -1,0 +1,1 @@
+docker/web/Dockerfile


### PR DESCRIPTION
Create a 'web' Docker image that is similar to the workers image, except instead of starting workers, it installs the code and its requirements and then starts the `rq-dashboard` process.

The process is started with basic auth enabled, with the data being read from a file named `app/rq-credentials.txt` which should be mapped from the host container.

This will later be replaced with a full Flask app where rq-dashboard is only one part of it.