### PR TITLE
Fix flock/cron command

### DIFF
--- a/docker/workers/Dockerfile
+++ b/docker/workers/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
 RUN pip3 install -r app/requirements.txt
 
 # Schedule tasks through cron
-RUN echo "0 0  * * * root /usr/bin/flock -w 0 /dev/shm/enqueue-all.cron.lock    python /usr/src/app/enqueue-all.py    > /dev/shm/enqueue-all.cron.log    2>&1" > /etc/cron.d/enqueue-all
-RUN echo "0 23 * * * root /usr/bin/flock -w 0 /dev/shm/enqueue-global.cron.lock python /usr/src/app/enqueue-global.py > /dev/shm/enqueue-global.cron.log 2>&1" > /etc/cron.d/enqueue-global
+RUN echo "0 0 * * * * /usr/bin/flock -n /run/lock/enqueue-all.cron.lock    -c 'python /usr/src/app/enqueue-all.py    > /dev/shm/enqueue-all.cron.log    2>&1'" > /etc/cron.d/enqueue-all
+RUN echo "0 4 * * * * /usr/bin/flock -n /run/lock/enqueue-global.cron.lock -c 'python /usr/src/app/enqueue-global.py > /dev/shm/enqueue-global.cron.log 2>&1'" > /etc/cron.d/enqueue-global
 
 # Start
 CMD cron && supervisord -c /usr/src/app/supervisord.conf -n


### PR DESCRIPTION
* `flock -w 0` is better represented by `-n` (don't wait for lock)
* The flock command must be preceded by the `-c` flag and quoted
* A crontab entry has 6 space separated parts not 5
* There is no need for 'root' in the cron entry, it doesn't do anything