### PR TITLE
Fixes the women's cricket table and any other table with a single column

### DIFF
--- a/wp1/templates/table.jinja2
+++ b/wp1/templates/table.jinja2
@@ -4,7 +4,7 @@
 ! colspan="{{total_cols}}" class="ratingstabletitle" | {{title}}
 |-
 ! rowspan="2" style="vertical-align: bottom" | '''Quality'''
-! colspan="{{total_cols - 1}}" | '''Importance'''
+{% if not is_single_col %}! colspan="{{total_cols - 1}}" | '''Importance'''{% endif %}
 |-
 {% for col in ordered_cols -%}
 ! {{col_labels[col]}}


### PR DESCRIPTION
Fixes #50. We prepared an `is_single_col` parameter for the template, but forgot to use it.