### PR TITLE
Create a separate cron job for updating the global_articles table

### DIFF
--- a/cron/update-global-articles.sh
+++ b/cron/update-global-articles.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export PATH=/usr/local/bin:$PATH
+cd /usr/src/app
+
+exec 200>/run/lock/update-global-articles.cron.lock
+flock -n 200 || exit 1
+
+supervisorctl -c supervisord.conf stop wp1-update:*
+python update-global-articles.py
+supervisorctl -c supervisord.conf start wp1-update:*

--- a/docker/workers/Dockerfile
+++ b/docker/workers/Dockerfile
@@ -14,6 +14,7 @@ RUN pip3 install -r app/requirements.txt
 
 # Schedule tasks through cron
 RUN echo "0 0 * * * root /usr/src/app/cron/enqueue-all.sh > /var/log/enqueue-all.cron.log 2>&1" > /etc/cron.d/enqueue-all
+RUN echo "0 4 * * * root /usr/src/app/cron/update-global-articles.sh > /var/log/update-global-articles.cron.log 2>&1" > /etc/cron.d/update-global-articles
 RUN echo "0 5 * * * root /usr/src/app/cron/enqueue-global.sh > /var/log/enqueue-global.cron.log 2>&1" > /etc/cron.d/enqueue-global
 
 # Start

--- a/enqueue-all.py
+++ b/enqueue-all.py
@@ -1,4 +1,3 @@
-import re
 import sys
 
 from redis import Redis
@@ -6,37 +5,8 @@ from rq import Queue
 
 from wp1 import constants
 from wp1 import tables
-from wp1.conf import get_conf
-from wp1.logic import page as logic_page, project as logic_project
+from wp1.logic import project as logic_project
 from wp1.wiki_db import connect as wiki_connect
-
-config = get_conf()
-ROOT_CATEGORY = config['ROOT_CATEGORY'].encode('utf-8')
-CATEGORY_NS = config['CATEGORY_NS'].encode('utf-8')
-BY_QUALITY = config['BY_QUALITY'].encode('utf-8')
-BY_IMPORTANCE = config['BY_IMPORTANCE'].encode('utf-8')
-ARTICLES_LABEL = config['ARTICLES_LABEL'].encode('utf-8')
-
-RE_REJECT_GENERIC = re.compile(ARTICLES_LABEL + b'_' + BY_QUALITY, re.I)
-
-
-def project_names_to_update(wikidb):
-  projects_in_root = logic_page.get_pages_by_category(
-    wikidb, ROOT_CATEGORY, constants.CATEGORY_NS_INT)
-  # List instead of iterate because the query will be reused in the processing
-  # steps and if we don't exhaust it now, it will get truncated.
-  for category_page in list(projects_in_root):
-    if BY_QUALITY not in category_page.page_title:
-      print('Skipping %s -- it does not have quality in title' %
-                    category_page.page_title.decode('utf-8'))
-      continue
-
-    if RE_REJECT_GENERIC.match(category_page.page_title):
-      print('Skipping %r -- it is a generic "articles by quality"' %
-                    category_page)
-      continue
-
-    yield category_page.base_title
 
 
 def main():
@@ -52,7 +22,7 @@ def main():
     return
 
   wikidb = wiki_connect()
-  for project_name in project_names_to_update(wikidb):
+  for project_name in logic_project.project_names_to_update(wikidb):
     if upload_only:
       print('Enqueuing upload (dependent) %s' % project_name)
       upload_q.enqueue(
@@ -67,6 +37,7 @@ def main():
       upload_q.enqueue(
         tables.upload_project_table, project_name,
         depends_on=update_job, job_timeout=constants.JOB_TIMEOUT)
+
 
 if __name__ == '__main__':
   main()

--- a/update-global-articles.py
+++ b/update-global-articles.py
@@ -1,0 +1,22 @@
+import logging
+import sys
+
+from wp1 import constants
+from wp1 import tables
+from wp1.conf import get_conf
+from wp1.logic import page as logic_page, project as logic_project
+from wp1.wiki_db import connect as wiki_connect
+from wp1.wp10_db import connect as wp10_connect
+
+
+def main():
+  wikidb = wiki_connect()
+  wp10db = wp10_connect()
+
+  logging.basicConfig(level=logging.DEBUG)
+
+  for project_name in logic_project.project_names_to_update(wikidb):
+    logic_project.update_global_articles_for_project_name(wp10db, project_name)
+
+if __name__ == '__main__':
+  main()

--- a/wp1/logic/project_test.py
+++ b/wp1/logic/project_test.py
@@ -807,9 +807,7 @@ class GlobalArticlesTest(ArticlesTest):
     logic_project.update_global_articles_for_project_name(
       self.wp10db, self.project.p_project)
 
-    self.maxDiff = None
     actual = _get_all_global_article_scores(self.wp10db)
-    from pprint import pprint; pprint(actual)
     actual = sorted(sorted(list(a.items())) for a in actual)
     expected = sorted(sorted(list(e.items())) for e in expected)
     self.assertEqual(expected, actual)


### PR DESCRIPTION
Since we discovered in #71 that updating the global_articles table cannot be done in parallel, add a cron job for updating it at 4 AM UTC.

This PR includes a refactor of the code for getting the names of all projects to update, and tests for the same. It also includes some refactoring of tests so that they are better organized.

(Fixes #71)