### PR TITLE
Try a no-op to refresh login status on the API site object

### DIFF
--- a/wp1/api.py
+++ b/wp1/api.py
@@ -47,5 +47,9 @@ def save_page(page, wikicode, msg):
   except mwclient.errors.AssertUserFailedError as e:
     logger.warning('Got login exception, retrying login')
     login()
+    # Retrieve a token from the api, which will cause the userinfo to refresh and site.logged_in
+    # to have the correct value. This is a necessary workaround for this bug:
+    # https://github.com/mwclient/mwclient/issues/231
+    page.get_token('edit', force=True)
     page.save(wikicode, msg)
   return True

--- a/wp1/api_test.py
+++ b/wp1/api_test.py
@@ -42,9 +42,9 @@ class ApiTest(unittest.TestCase):
   def test_save_page_tries_login_on_exception(self, patched_login, patched_site):
     self.page.save.side_effect = mwclient.errors.AssertUserFailedError()
     with self.assertRaises(mwclient.errors.AssertUserFailedError):
-      actual = wp1.api.save_page(self.page, '<code>', 'edit summary')
-      self.assertTrue(actual)
-      self.assertEqual(1, patched_login.call_count)
+      wp1.api.save_page(self.page, '<code>', 'edit summary')
+
+    self.assertEqual(1, patched_login.call_count)
 
   @patch('wp1.api')
   def test_save_page_skips_login_on_none_site(self, patched_api):

--- a/wp1/api_test.py
+++ b/wp1/api_test.py
@@ -44,7 +44,7 @@ class ApiTest(unittest.TestCase):
     with self.assertRaises(mwclient.errors.AssertUserFailedError):
       actual = wp1.api.save_page(self.page, '<code>', 'edit summary')
       self.assertTrue(actual)
-      self.assertEqual(1, len(patched_login.call_args_list))
+      self.assertEqual(1, patched_login.call_count)
 
   @patch('wp1.api')
   def test_save_page_skips_login_on_none_site(self, patched_api):


### PR DESCRIPTION
Fixes #69.