### PR TITLE
New strategy for dealing with failed page edits

### DIFF
--- a/wp1/api.py
+++ b/wp1/api.py
@@ -45,11 +45,12 @@ def save_page(page, wikicode, msg):
   try:
     page.save(wikicode, msg)
   except mwclient.errors.AssertUserFailedError as e:
-    logger.warning('Got login exception, retrying login')
+    logger.warning('Got login exception, creating new site object')
     login()
-    # Retrieve a token from the api, which will cause the userinfo to refresh and site.logged_in
-    # to have the correct value. This is a necessary workaround for this bug:
+
+    # Get a new copy of the page, since page.save is tied to page.site and that refers to the old
+    # site from before we did the re-login. All of this is a workaround for:
     # https://github.com/mwclient/mwclient/issues/231
-    page.get_token('edit', force=True)
+    page = get_page(page.name)
     page.save(wikicode, msg)
   return True

--- a/wp1/api_test.py
+++ b/wp1/api_test.py
@@ -39,12 +39,13 @@ class ApiTest(unittest.TestCase):
 
   @patch('wp1.api.site')
   @patch('wp1.api.login')
-  def test_save_page_tries_login_on_exception(self, patched_login, patched_site):
+  @patch('wp1.api.get_page')
+  def test_save_page_retries_on_exception(
+      self, patched_get_page, patched_login, patched_site):
     self.page.save.side_effect = mwclient.errors.AssertUserFailedError()
-    with self.assertRaises(mwclient.errors.AssertUserFailedError):
-      wp1.api.save_page(self.page, '<code>', 'edit summary')
-
+    wp1.api.save_page(self.page, '<code>', 'edit summary')
     self.assertEqual(1, patched_login.call_count)
+    self.assertEqual(1, patched_get_page.call_count)
 
   @patch('wp1.api')
   def test_save_page_skips_login_on_none_site(self, patched_api):


### PR DESCRIPTION
As stated in the comment in the code, since the site is tied to the page itself, get a new page object from the API when we re-login. Fixes #69.