### PR TITLE
Restart the upload worker jobs as part of the cron job to avoid #69

### DIFF
--- a/cron/enqueue-all.sh
+++ b/cron/enqueue-all.sh
@@ -1,3 +1,4 @@
 export PATH=/usr/local/bin:$PATH
 cd /usr/src/app
+supervisorctl -c supervisord.conf restart wp1-upload:*
 flock -n /run/lock/enqueue-all.cron.lock -c "python enqueue-all.py"


### PR DESCRIPTION
Additional fix for #69, otherwise the workers will probably hit a login rate limit. See discussion in #80.