### PR TITLE
Fix for duplicate logs.

### DIFF
--- a/wp1/logic/project.py
+++ b/wp1/logic/project.py
@@ -289,10 +289,10 @@ def update_project_assessments_by_kind(
           logic_rating.add_log_for_rating(
               wp10db, rating, kind, old_rating_value)
           # And update the rating of course.
-          logic_rating.insert_or_update(wp10db, rating)
+          logic_rating.insert_or_update(wp10db, rating, kind)
       else:
         # Add the newly created rating.
-        logic_rating.insert_or_update(wp10db, rating)
+        logic_rating.insert_or_update(wp10db, rating, kind)
         logic_rating.add_log_for_rating(
           wp10db, rating, kind, NOT_A_CLASS)
 
@@ -363,7 +363,7 @@ def process_unseen_articles(wikidb, wp10db, project, old_ratings, seen):
       else:
         rating.r_importance_timestamp = GLOBAL_TIMESTAMP_WIKI
 
-    logic_rating.insert_or_update(wp10db, rating)
+    logic_rating.insert_or_update(wp10db, rating, kind)
 
     if kind in (AssessmentKind.QUALITY, AssessmentKind.BOTH):
       logic_rating.add_log_for_rating(


### PR DESCRIPTION
Fixes #83 

This bug was introduced when we switched from doing unseen articles after each quality/importance run, to doing them all at the end. Because of that, the `old_rating` doesn't get updated in between runs. So, when a new article appears that has both a quality and an importance rating, the rating for quality would be written, then it would be re-written with importance as a "new" rating, which would set the quality to NULL.

This manifests as duplicate logs because the next day, the `old_rating` is there, but has quality NotA-Class, so we write a log that the quality went from NotA-Class -> Whatever, which shows up in the logs as "assessed".