### PR TITLE
Format all code in the wp1 directory with yapf

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,3 @@
+[style]
+based_on_style = google
+indent_width = 2

--- a/wp1/api.py
+++ b/wp1/api.py
@@ -5,6 +5,7 @@ import mwclient
 logger = logging.getLogger(__name__)
 _ua = 'WP1.0Bot/3.0. Run by User:Audiodude. Using mwclient/0.9.1'
 
+
 def get_credentials():
   try:
     from wp1.credentials import API_CREDS
@@ -13,7 +14,10 @@ def get_credentials():
     # No credentials, probably in development environment.
     pass
 
+
 site = None
+
+
 def login():
   global site
   try:
@@ -30,12 +34,14 @@ def login():
 # Global login on startup.
 login()
 
+
 def get_page(name):
   if not site:
     logger.error('Could not get page %s because api site is not defined', name)
     return None
 
   return site.pages[name]
+
 
 def save_page(page, wikicode, msg):
   if not site:

--- a/wp1/api_test.py
+++ b/wp1/api_test.py
@@ -7,7 +7,9 @@ import mwclient
 
 import wp1.api
 
+
 class ApiWithCredsTest(unittest.TestCase):
+
   @patch('wp1.api.get_credentials')
   @patch('wp1.api.mwclient.Site')
   def test_login(self, patched_mwsite, patched_credentials):
@@ -18,7 +20,8 @@ class ApiWithCredsTest(unittest.TestCase):
   @patch('wp1.api.get_credentials')
   @patch('wp1.api.mwclient.Site')
   @patch('wp1.api.logger')
-  def test_login_exception(self, patched_logger, patched_mwsite, patched_credentials):
+  def test_login_exception(self, patched_logger, patched_mwsite,
+                           patched_credentials):
     site = patched_mwsite()
     print('in test', site)
     site.login.side_effect = mwclient.errors.LoginError()
@@ -27,6 +30,7 @@ class ApiWithCredsTest(unittest.TestCase):
 
 
 class ApiTest(unittest.TestCase):
+
   def setUp(self):
     self.page = MagicMock()
     self.original_save_page = wp1.api.save_page
@@ -40,8 +44,8 @@ class ApiTest(unittest.TestCase):
   @patch('wp1.api.site')
   @patch('wp1.api.login')
   @patch('wp1.api.get_page')
-  def test_save_page_retries_on_exception(
-      self, patched_get_page, patched_login, patched_site):
+  def test_save_page_retries_on_exception(self, patched_get_page, patched_login,
+                                          patched_site):
     self.page.save.side_effect = mwclient.errors.AssertUserFailedError()
     wp1.api.save_page(self.page, '<code>', 'edit summary')
     self.assertEqual(1, patched_login.call_count)

--- a/wp1/base_db_test.py
+++ b/wp1/base_db_test.py
@@ -32,6 +32,7 @@ def parse_sql(filename):
 
 
 class BaseWpOneDbTest(unittest.TestCase):
+
   def _cleanup_wp_one_db(self):
     stmts = parse_sql('wp10_test.down.sql')
     with self.wp10db.cursor() as cursor:
@@ -41,13 +42,12 @@ class BaseWpOneDbTest(unittest.TestCase):
     self.wp10db.close()
 
   def _setup_wp_one_db(self):
-    self.wp10db = pymysql.connect(
-      host='localhost',
-      db='enwp10_test',
-      user='root',
-      charset=None,
-      use_unicode=False,
-      cursorclass=pymysql.cursors.DictCursor)
+    self.wp10db = pymysql.connect(host='localhost',
+                                  db='enwp10_test',
+                                  user='root',
+                                  charset=None,
+                                  use_unicode=False,
+                                  cursorclass=pymysql.cursors.DictCursor)
     stmts = parse_sql('wp10_test.up.sql')
     with self.wp10db.cursor() as cursor:
       for stmt in stmts:
@@ -58,7 +58,9 @@ class BaseWpOneDbTest(unittest.TestCase):
     self.addCleanup(self._cleanup_wp_one_db)
     self._setup_wp_one_db()
 
+
 class BaseWikiDbTest(unittest.TestCase):
+
   def _cleanup_wiki_db(self):
     stmts = parse_sql('wiki_test.down.sql')
     with self.wikidb.cursor() as cursor:
@@ -68,13 +70,12 @@ class BaseWikiDbTest(unittest.TestCase):
     self.wikidb.close()
 
   def _setup_wiki_db(self):
-    self.wikidb = pymysql.connect(
-      host='localhost',
-      db='enwikip_test',
-      user='root',
-      charset=None,
-      use_unicode=False,
-      cursorclass=pymysql.cursors.DictCursor)
+    self.wikidb = pymysql.connect(host='localhost',
+                                  db='enwikip_test',
+                                  user='root',
+                                  charset=None,
+                                  use_unicode=False,
+                                  cursorclass=pymysql.cursors.DictCursor)
     stmts = parse_sql('wiki_test.up.sql')
     with self.wikidb.cursor() as cursor:
       for stmt in stmts:
@@ -87,6 +88,7 @@ class BaseWikiDbTest(unittest.TestCase):
 
 
 class BaseCombinedDbTest(BaseWikiDbTest, BaseWpOneDbTest):
+
   def setUp(self):
     self.addCleanup(self._cleanup_wiki_db)
     self._setup_wiki_db()

--- a/wp1/conf.py
+++ b/wp1/conf.py
@@ -2,12 +2,15 @@ import os
 
 import json
 
+
 def _get_conf_path():
   return os.path.join(os.path.dirname(os.path.dirname(__file__)), 'conf.json')
+
 
 _conf = None
 with open(_get_conf_path()) as f:
   _conf = json.load(f)
+
 
 def get_conf():
   return dict(_conf)

--- a/wp1/constants.py
+++ b/wp1/constants.py
@@ -1,10 +1,12 @@
 import enum
 import time
 
+
 class AssessmentKind(enum.Enum):
   QUALITY = 'quality'
   IMPORTANCE = 'importance'
   BOTH = 'both'
+
 
 MAX_ARTICLES_BEFORE_COMMIT = 200
 
@@ -20,4 +22,4 @@ GLOBAL_TIMESTAMP_WIKI = time.strftime(TS_FORMAT, time.gmtime()).encode('utf-8')
 LIST_URL = 'https://tools.wmflabs.org/enwp10/cgi-bin/list2.fcgi'
 
 # Timeout for the rq worker jobs, in seconds
-JOB_TIMEOUT=60 * 60 * 2  # 2 hours
+JOB_TIMEOUT = 60 * 60 * 2  # 2 hours

--- a/wp1/logic/api/page.py
+++ b/wp1/logic/api/page.py
@@ -8,6 +8,7 @@ import wp1.logic.util as logic_util
 
 logger = logging.getLogger(__name__)
 
+
 def get_redirect(title_with_ns):
   logger.debug('Querying api for redirects for %s', title_with_ns)
 
@@ -15,8 +16,11 @@ def get_redirect(title_with_ns):
   retries = 3
   while retries:
     try:
-      res = site.api('query', titles=title_with_ns, redirects=1,
-                     prop='revisions', rvlimit=1)
+      res = site.api('query',
+                     titles=title_with_ns,
+                     redirects=1,
+                     prop='revisions',
+                     rvlimit=1)
       break
     except:
       retries -= 1
@@ -25,19 +29,21 @@ def get_redirect(title_with_ns):
     logger.warn('Error contacting API, returning None')
     return None
 
-  if ('query' not in res or
-      'redirects' not in res['query'] or
+  if ('query' not in res or 'redirects' not in res['query'] or
       len(res['query']['redirects'][0]['to']) == 0):
     return None
 
   key = next(iter(res['query']['pages']))
   page = res['query']['pages'][key]
   return {
-    'ns': page['ns'],
-    'title': page['title'].replace(' ', '_'),
-    'timestamp_dt': datetime.strptime(
-      page['revisions'][0]['timestamp'], TS_FORMAT),
+      'ns':
+          page['ns'],
+      'title':
+          page['title'].replace(' ', '_'),
+      'timestamp_dt':
+          datetime.strptime(page['revisions'][0]['timestamp'], TS_FORMAT),
   }
+
 
 def get_moves(title_with_ns):
   logger.debug('Querying api for moves of page %s', title_with_ns)
@@ -63,9 +69,12 @@ def get_moves(title_with_ns):
         if 'params' not in event:
           continue
         ans.append({
-          'ns': event['params']['target_ns'],
-          'title': event['params']['target_title'].replace(' ', '_'),
-          'timestamp_dt': datetime.fromtimestamp(time.mktime(event['timestamp'])),
+            'ns':
+                event['params']['target_ns'],
+            'title':
+                event['params']['target_title'].replace(' ', '_'),
+            'timestamp_dt':
+                datetime.fromtimestamp(time.mktime(event['timestamp'])),
         })
       break
     except:

--- a/wp1/logic/api/project.py
+++ b/wp1/logic/api/project.py
@@ -16,10 +16,11 @@ CATEGORY_NS_STR = config['CATEGORY_NS']
 
 RE_EXTRA = re.compile(r'extra(\d)-(.+)')
 
+
 def get_extra_assessments(project_name):
   ans = {'extra': {}}
   page_name = logic_util.category_for_project_by_kind(
-    project_name, AssessmentKind.QUALITY).decode('utf-8')
+      project_name, AssessmentKind.QUALITY).decode('utf-8')
   logging.debug('Retrieving page %s from API', page_name)
   page = api.get_page(page_name)
   if page is None:
@@ -45,16 +46,15 @@ def get_extra_assessments(project_name):
   for param in template.params:
     md = RE_EXTRA.match(param.name.strip())
     if md:
-      extra[md.group(1)][md.group(2)] = (
-        template.get(param.name).value.strip())
+      extra[md.group(1)][md.group(2)] = (template.get(param.name).value.strip())
 
   for num_str, params in extra.items():
     if ('title' not in params or 'type' not in params or
         'category' not in params or 'ranking' not in params):
       continue
 
-    category = params['category'].replace('%s:' % CATEGORY_NS_STR, '').replace(
-      ' ', '_')
+    category = params['category'].replace('%s:' % CATEGORY_NS_STR,
+                                          '').replace(' ', '_')
     params['category'] = category
     ans['extra'][category] = params
 

--- a/wp1/logic/api/project_test.py
+++ b/wp1/logic/api/project_test.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import wp1.logic.api.project as api_project
 
+
 class TestApiProject(unittest.TestCase):
   page_text = ("{{ReleaseVersionParameters\n |hidden=yes\n |homepage="
                "Wikipedia:WikiProject Catholicism\n}}\n[[File:Juan de Juanes "
@@ -12,22 +13,20 @@ class TestApiProject(unittest.TestCase):
                "Catholicism|WikiProject Catholicism]]''' article assessment "
                "and rating scheme.")
 
-  page_text_extra = ("{{ReleaseVersionParameters\n |hidden=yes\n |homepage="
-               "Wikipedia:WikiProject Catholicism\n|extra1-title="
-               "Foo Bar Baz\n|extra1-type=quality\n|extra1-category="
-               "Category:Foo\n|extra1-ranking=300}}\n[[File:Juan de Juanes "
-               "003.jpg|thumb|right|300px]]\nThis category contains "
-               "subcategories of articles according to their currently "
-               "assessed quality rating in the '''[[Wikipedia:WikiProject "
-               "Catholicism|WikiProject Catholicism]]''' article assessment "
-               "and rating scheme.")
+  page_text_extra = (
+      "{{ReleaseVersionParameters\n |hidden=yes\n |homepage="
+      "Wikipedia:WikiProject Catholicism\n|extra1-title="
+      "Foo Bar Baz\n|extra1-type=quality\n|extra1-category="
+      "Category:Foo\n|extra1-ranking=300}}\n[[File:Juan de Juanes "
+      "003.jpg|thumb|right|300px]]\nThis category contains "
+      "subcategories of articles according to their currently "
+      "assessed quality rating in the '''[[Wikipedia:WikiProject "
+      "Catholicism|WikiProject Catholicism]]''' article assessment "
+      "and rating scheme.")
 
   @patch('wp1.logic.api.project.api')
   def test_get_extra_assessments_homepage_only(self, patched_api):
-    expected = {
-      'extra': {},
-      'homepage': 'Wikipedia:WikiProject Catholicism'
-    }
+    expected = {'extra': {}, 'homepage': 'Wikipedia:WikiProject Catholicism'}
     page = MagicMock()
     page.text.return_value = self.page_text
     patched_api.get_page.return_value = page
@@ -38,15 +37,15 @@ class TestApiProject(unittest.TestCase):
   @patch('wp1.logic.api.project.api')
   def test_get_extra_assessments_extra(self, patched_api):
     expected = {
-      'extra': {
-        'Foo': {
-          'title': 'Foo Bar Baz',
-          'category': 'Foo',
-          'ranking': '300',
-          'type': 'quality',
+        'extra': {
+            'Foo': {
+                'title': 'Foo Bar Baz',
+                'category': 'Foo',
+                'ranking': '300',
+                'type': 'quality',
+            },
         },
-      },
-      'homepage': 'Wikipedia:WikiProject Catholicism'
+        'homepage': 'Wikipedia:WikiProject Catholicism'
     }
     page = MagicMock()
     page.text.return_value = self.page_text_extra

--- a/wp1/logic/category.py
+++ b/wp1/logic/category.py
@@ -2,9 +2,11 @@ import attr
 
 from wp1.models.wp10.category import Category
 
+
 def insert_or_update(wp10db, category):
   with wp10db.cursor() as cursor:
-    cursor.execute('''INSERT INTO ''' + Category.table_name + '''
+    cursor.execute(
+        '''INSERT INTO ''' + Category.table_name + '''
       (c_project, c_type, c_rating, c_replacement, c_category, c_ranking)
       VALUES (%(c_project)s, %(c_type)s, %(c_rating)s, %(c_replacement)s,
               %(c_category)s, %(c_ranking)s)

--- a/wp1/logic/log.py
+++ b/wp1/logic/log.py
@@ -2,9 +2,11 @@ import attr
 
 from wp1.models.wp10.log import Log
 
+
 def insert_or_update(wp10db, log):
   with wp10db.cursor() as cursor:
-    cursor.execute('''INSERT INTO ''' + Log.table_name + '''
+    cursor.execute(
+        '''INSERT INTO ''' + Log.table_name + '''
       (l_project, l_namespace, l_article, l_action, l_timestamp, l_old, l_new,
        l_revision_timestamp)
       VALUES (%(l_project)s, %(l_namespace)s, %(l_article)s, %(l_action)s,

--- a/wp1/logic/move.py
+++ b/wp1/logic/move.py
@@ -2,23 +2,27 @@ import attr
 
 from wp1.models.wp10.move import Move
 
+
 def get_move(wp10db, timestamp, old_namespace, old_article):
   with wp10db.cursor() as cursor:
-    cursor.execute('SELECT * FROM ' + Move.table_name + '''
+    cursor.execute(
+        'SELECT * FROM ' + Move.table_name + '''
       WHERE m_timestamp = %(m_timestamp)s AND
             m_old_namespace = %(m_old_namespace)s AND
             m_old_article = %(m_old_article)s
     ''', {
-      'm_timestamp': timestamp,
-      'm_old_namespace': old_namespace,
-      'm_old_article': old_article,
-    })
+            'm_timestamp': timestamp,
+            'm_old_namespace': old_namespace,
+            'm_old_article': old_article,
+        })
     db_move = cursor.fetchone()
     return Move(**db_move) if db_move else None
 
+
 def insert(wp10db, move):
   with wp10db.cursor() as cursor:
-    cursor.execute('INSERT INTO ' + Move.table_name + '''
+    cursor.execute(
+        'INSERT INTO ' + Move.table_name + '''
       (m_timestamp, m_old_namespace, m_old_article, m_new_namespace, m_new_article)
       VALUES (%(m_timestamp)s, %(m_old_namespace)s, %(m_old_article)s, %(m_new_namespace)s,
               %(m_new_article)s)

--- a/wp1/logic/page.py
+++ b/wp1/logic/page.py
@@ -12,6 +12,7 @@ import wp1.logic.util as logic_util
 
 logger = logging.getLogger(__name__)
 
+
 def get_pages_by_category(wikidb, category, ns=None):
   query = '''
     SELECT page_namespace, page_title, page_id, cl_sortkey, cl_timestamp 
@@ -25,7 +26,7 @@ def get_pages_by_category(wikidb, category, ns=None):
   if ns is not None:
     query += ' AND page_namespace = %(ns)s'
     params['ns'] = ns
- 
+
   with wikidb.cursor() as cursor:
     cursor.execute(query, params)
     while True:
@@ -35,26 +36,31 @@ def get_pages_by_category(wikidb, category, ns=None):
       yield Page(**result)
 
 
-def update_page_moved(
-    wp10db, project, old_ns, old_title, new_ns, new_title,
-    move_timestamp_dt):
-  logger.debug('Updating moves table for %s -> %s',
-               old_title.decode('utf-8'), new_title.decode('utf-8'))
+def update_page_moved(wp10db, project, old_ns, old_title, new_ns, new_title,
+                      move_timestamp_dt):
+  logger.debug('Updating moves table for %s -> %s', old_title.decode('utf-8'),
+               new_title.decode('utf-8'))
   db_timestamp = move_timestamp_dt.strftime(TS_FORMAT).encode('utf-8')
 
   existing_move = logic_move.get_move(wp10db, db_timestamp, old_ns, old_title)
   if existing_move is not None:
     logger.debug('Move already recorded: %r', existing_move)
   else:
-    new_move = Move(
-      m_timestamp=db_timestamp, m_old_namespace=old_ns, m_old_article=old_title,
-      m_new_namespace=new_ns, m_new_article=new_title)
+    new_move = Move(m_timestamp=db_timestamp,
+                    m_old_namespace=old_ns,
+                    m_old_article=old_title,
+                    m_new_namespace=new_ns,
+                    m_new_article=new_title)
     logic_move.insert(wp10db, new_move)
 
-  new_log = Log(
-    l_project=project.p_project, l_namespace=old_ns, l_article=old_title,
-    l_action=b'moved', l_timestamp=GLOBAL_TIMESTAMP, l_old=b'', l_new=b'',
-    l_revision_timestamp=db_timestamp)
+  new_log = Log(l_project=project.p_project,
+                l_namespace=old_ns,
+                l_article=old_title,
+                l_action=b'moved',
+                l_timestamp=GLOBAL_TIMESTAMP,
+                l_old=b'',
+                l_new=b'',
+                l_revision_timestamp=db_timestamp)
   logic_log.insert_or_update(wp10db, new_log)
 
 
@@ -62,18 +68,22 @@ def _get_redirects_from_db(wikidb, namespace, title, timestamp_dt):
   wiki_db_title = title.decode('utf-8').replace(' ', '_')
   wikidb.ping()
   with wikidb.cursor() as cursor:
-    cursor.execute('''SELECT rd_namespace, rd_title, page_touched FROM page
+    cursor.execute(
+        '''SELECT rd_namespace, rd_title, page_touched FROM page
       JOIN redirect ON page_id = rd_from AND
         page_title = %(title)s AND page_namespace = %(namespace)s
-    ''', {'title': wiki_db_title, 'namespace': namespace})
+    ''', {
+            'title': wiki_db_title,
+            'namespace': namespace
+        })
     row = cursor.fetchone()
     if row:
-      timestamp_dt = datetime.strptime(
-        row['page_touched'].decode('utf-8'), '%Y%m%d%H%M%S')
+      timestamp_dt = datetime.strptime(row['page_touched'].decode('utf-8'),
+                                       '%Y%m%d%H%M%S')
       return {
-        'dest_ns': row['rd_namespace'],
-        'dest_title': row['rd_title'],
-        'timestamp_dt': timestamp_dt,
+          'dest_ns': row['rd_namespace'],
+          'dest_title': row['rd_title'],
+          'timestamp_dt': timestamp_dt,
       }
     return None
 
@@ -85,9 +95,9 @@ def _get_moves_from_api(wp10db, namespace, title, timestamp_dt):
     for move in moves:
       if move['timestamp_dt'] > timestamp_dt:
         return {
-          'dest_ns': move['ns'],
-          'dest_title': move['title'].encode('utf-8'),
-          'timestamp_dt': move['timestamp_dt'],
+            'dest_ns': move['ns'],
+            'dest_title': move['title'].encode('utf-8'),
+            'timestamp_dt': move['timestamp_dt'],
         }
   return None
 
@@ -102,9 +112,9 @@ def _get_redirects_from_api(wp10db, namespace, title, timestamp_dt):
 
   if redir is not None and redir['timestamp_dt'] > timestamp_dt:
     return {
-      'dest_ns': redir['ns'],
-      'dest_title': redir['title'].encode('utf-8'),
-      'timestamp_dt': redir['timestamp_dt'],
+        'dest_ns': redir['ns'],
+        'dest_title': redir['title'].encode('utf-8'),
+        'timestamp_dt': redir['timestamp_dt'],
     }
   return None
 

--- a/wp1/logic/page_test.py
+++ b/wp1/logic/page_test.py
@@ -28,38 +28,73 @@ def get_all_logs(wp10db):
 
 
 class LogicPageCategoryTest(BaseWikiDbTest):
+
   def setUp(self):
     super().setUp()
     ts = datetime(2018, 9, 30, 12, 30, 0)
     with self.wikidb.cursor() as cursor:
       pages = [
-        {'id': 100, 'ns': 0, 'title': b'The cape of Superman'},
-        {'id': 101, 'ns': 0, 'title': b'Powers of Superman'},
-        {'id': 102, 'ns': 14, 'title': b'Places Superman vacations'},
-        {'id': 103, 'ns': 14, 'title': b'Superman Facts'},
+          {
+              'id': 100,
+              'ns': 0,
+              'title': b'The cape of Superman'
+          },
+          {
+              'id': 101,
+              'ns': 0,
+              'title': b'Powers of Superman'
+          },
+          {
+              'id': 102,
+              'ns': 14,
+              'title': b'Places Superman vacations'
+          },
+          {
+              'id': 103,
+              'ns': 14,
+              'title': b'Superman Facts'
+          },
       ]
       for page in pages:
-        cursor.execute('''
+        cursor.execute(
+            '''
           INSERT INTO page (page_id, page_namespace, page_title)
           VALUES (%(id)s, %(ns)s, %(title)s)
         ''', page)
       cls = [
-        {'from': 100, 'to': b'Articles about Superman', 'timestamp': ts},
-        {'from': 101, 'to': b'Articles about Superman', 'timestamp': ts},
-        {'from': 102, 'to': b'Articles about Superman', 'timestamp': ts},
-        {'from': 103, 'to': b'Articles about Superman', 'timestamp': ts},
+          {
+              'from': 100,
+              'to': b'Articles about Superman',
+              'timestamp': ts
+          },
+          {
+              'from': 101,
+              'to': b'Articles about Superman',
+              'timestamp': ts
+          },
+          {
+              'from': 102,
+              'to': b'Articles about Superman',
+              'timestamp': ts
+          },
+          {
+              'from': 103,
+              'to': b'Articles about Superman',
+              'timestamp': ts
+          },
       ]
       for cl in cls:
-        cursor.execute('''
+        cursor.execute(
+            '''
           INSERT INTO categorylinks (cl_from, cl_to, cl_timestamp)
           VALUES (%(from)s, %(to)s, %(timestamp)s)
         ''', cl)
     self.wikidb.commit()
-    
+
   def test_get_category_pages(self):
     titles = set()
-    for page in logic_page.get_pages_by_category(
-        self.wikidb, b'Articles about Superman'):
+    for page in logic_page.get_pages_by_category(self.wikidb,
+                                                 b'Articles about Superman'):
       titles.add(page.page_title)
 
     self.assertEqual(4, len(titles))
@@ -70,8 +105,9 @@ class LogicPageCategoryTest(BaseWikiDbTest):
 
   def test_get_category_pages_ns_filter(self):
     titles = set()
-    for page in logic_page.get_pages_by_category(
-        self.wikidb, b'Articles about Superman', ns=14):
+    for page in logic_page.get_pages_by_category(self.wikidb,
+                                                 b'Articles about Superman',
+                                                 ns=14):
       titles.add(page.page_title)
 
     self.assertEqual(2, len(titles))
@@ -80,6 +116,7 @@ class LogicPageCategoryTest(BaseWikiDbTest):
 
 
 class LogicPageMovesTest(BaseCombinedDbTest):
+
   def setUp(self):
     super().setUp()
     self.timestamp_str = '2011-04-28T12:30:00Z'
@@ -88,55 +125,63 @@ class LogicPageMovesTest(BaseCombinedDbTest):
     self.expected_dt = datetime.strptime(self.timestamp_str, TS_FORMAT)
 
     self.api_return = {
-      'query': {
-        'redirects': [{'to': self.expected_title}],
-        'pages': {123: {
-          'ns': self.expected_ns,
-          'title': self.expected_title,
-          'revisions': [{'timestamp': self.timestamp_str}],
-        }},
-      },
+        'query': {
+            'redirects': [{
+                'to': self.expected_title
+            }],
+            'pages': {
+                123: {
+                    'ns': self.expected_ns,
+                    'title': self.expected_title,
+                    'revisions': [{
+                        'timestamp': self.timestamp_str
+                    }],
+                }
+            },
+        },
     }
 
     self.le_return = [{
-      'params': {
-        'target_ns': self.expected_ns,
-        'target_title': self.expected_title,
-      },
-      'timestamp': time.strptime(self.timestamp_str, TS_FORMAT),
+        'params': {
+            'target_ns': self.expected_ns,
+            'target_title': self.expected_title,
+        },
+        'timestamp': time.strptime(self.timestamp_str, TS_FORMAT),
     }]
 
     self.le_multi = [{
-      'params': {
-        'target_ns': self.expected_ns,
-        'target_title': self.expected_title,
-      },
-      'timestamp': time.strptime(self.timestamp_str, TS_FORMAT),
+        'params': {
+            'target_ns': self.expected_ns,
+            'target_title': self.expected_title,
+        },
+        'timestamp': time.strptime(self.timestamp_str, TS_FORMAT),
     }, {
-      'params': {
-        'target_ns': self.expected_ns + 10,
-        'target_title': 'Some other article',
-      },
-      'timestamp': time.strptime('2010-08-08T12:30:00Z', TS_FORMAT),
+        'params': {
+            'target_ns': self.expected_ns + 10,
+            'target_title': 'Some other article',
+        },
+        'timestamp': time.strptime('2010-08-08T12:30:00Z', TS_FORMAT),
     }, {
-      'params': {
-        'target_ns': self.expected_ns + 20,
-        'target_title': 'Another crazy article',
-      },
-      'timestamp': time.strptime('2008-08-08T12:30:00Z', TS_FORMAT),
-  }]
+        'params': {
+            'target_ns': self.expected_ns + 20,
+            'target_title': 'Another crazy article',
+        },
+        'timestamp': time.strptime('2008-08-08T12:30:00Z', TS_FORMAT),
+    }]
 
   @patch('wp1.logic.api.page.site')
   def test_no_redirect_no_move(self, unused_patched_site):
-    move_data = logic_page.get_move_data(
-      self.wp10db, self.wikidb, 0, b'Some Moved Article', datetime(1970, 1, 1))
+    move_data = logic_page.get_move_data(self.wp10db, self.wikidb, 0,
+                                         b'Some Moved Article',
+                                         datetime(1970, 1, 1))
     self.assertIsNone(move_data)
 
   @patch('wp1.logic.api.page.site')
   def test_get_redirect_from_api(self, patched_site):
     patched_site.api.side_effect = lambda *args, **kwargs: self.api_return
-    move_data = logic_page.get_move_data(
-      self.wp10db, self.wikidb, 0, b'Some Moved Article', datetime(1970, 1, 1))
+    move_data = logic_page.get_move_data(self.wp10db, self.wikidb, 0,
+                                         b'Some Moved Article',
+                                         datetime(1970, 1, 1))
 
     self.assertIsNotNone(move_data)
     self.assertEqual(self.expected_ns, move_data['dest_ns'])
@@ -147,8 +192,9 @@ class LogicPageMovesTest(BaseCombinedDbTest):
   @patch('wp1.logic.api.page.site')
   def test_get_single_move_from_api(self, patched_site):
     patched_site.logevents.side_effect = lambda *args, **kwargs: self.le_return
-    move_data = logic_page.get_move_data(
-      self.wp10db, self.wikidb, 0, b'Some Moved Article', datetime(1970, 1, 1))
+    move_data = logic_page.get_move_data(self.wp10db, self.wikidb, 0,
+                                         b'Some Moved Article',
+                                         datetime(1970, 1, 1))
 
     self.assertIsNotNone(move_data)
     self.assertEqual(self.expected_ns, move_data['dest_ns'])
@@ -159,8 +205,9 @@ class LogicPageMovesTest(BaseCombinedDbTest):
   @patch('wp1.logic.api.page.site')
   def test_get_most_recent_move_from_api(self, patched_site):
     patched_site.logevents.side_effect = lambda *args, **kwargs: self.le_multi
-    move_data = logic_page.get_move_data(
-      self.wp10db, self.wikidb, 0, b'Some Moved Article', datetime(1970, 1, 1))
+    move_data = logic_page.get_move_data(self.wp10db, self.wikidb, 0,
+                                         b'Some Moved Article',
+                                         datetime(1970, 1, 1))
 
     self.assertIsNotNone(move_data)
     self.assertEqual(self.expected_ns, move_data['dest_ns'])
@@ -171,24 +218,27 @@ class LogicPageMovesTest(BaseCombinedDbTest):
   @patch('wp1.logic.api.page.site')
   def test_get_redirect_too_old_from_api(self, patched_site):
     patched_site.api.side_effect = lambda *args, **kwargs: self.api_return
-    move_data = logic_page.get_move_data(
-      self.wp10db, self.wikidb, 0, b'Some Moved Article', datetime(2014, 1, 1))
+    move_data = logic_page.get_move_data(self.wp10db, self.wikidb, 0,
+                                         b'Some Moved Article',
+                                         datetime(2014, 1, 1))
     self.assertIsNone(move_data)
-    
+
   @patch('wp1.logic.api.page.site')
   def test_get_single_move_too_old_from_api(self, patched_site):
     patched_site.logevents.side_effect = lambda *args, **kwargs: self.le_return
-    move_data = logic_page.get_move_data(
-      self.wp10db, self.wikidb, 0, b'Some Moved Article', datetime(2014, 1, 1))
+    move_data = logic_page.get_move_data(self.wp10db, self.wikidb, 0,
+                                         b'Some Moved Article',
+                                         datetime(2014, 1, 1))
     self.assertIsNone(move_data)
 
 
 class LogicPageMoveDbTest(BaseWpOneDbTest):
+
   def setUp(self):
     super().setUp()
     self.project = Project(p_project=b'Testing', p_timestamp='201001010000')
     logic_project.insert_or_update(self.wp10db, self.project)
-    
+
     self.old_ns = 0
     self.old_article = b'The history of testing'
     self.new_ns = 0
@@ -196,14 +246,14 @@ class LogicPageMoveDbTest(BaseWpOneDbTest):
     self.dt = datetime(2015, 4, 1)
     self.timestamp_db = self.dt.strftime(TS_FORMAT).encode('utf-8')
 
-  
   def test_new_move(self):
-    logic_page.update_page_moved(
-      self.wp10db, self.project, self.old_ns, self.old_article,
-      self.new_ns, self.new_article, self.dt)
+    logic_page.update_page_moved(self.wp10db, self.project, self.old_ns,
+                                 self.old_article, self.new_ns,
+                                 self.new_article, self.dt)
 
     with self.wp10db.cursor() as cursor:
-      cursor.execute('SELECT * FROM ' + Move.table_name + '''
+      cursor.execute(
+          'SELECT * FROM ' + Move.table_name + '''
         WHERE m_old_article = %(old_article)s
       ''', {'old_article': self.old_article})
       move = Move(**cursor.fetchone())
@@ -216,12 +266,13 @@ class LogicPageMoveDbTest(BaseWpOneDbTest):
     self.assertEqual(self.timestamp_db, move.m_timestamp)
 
   def test_new_move_log(self):
-    logic_page.update_page_moved(
-      self.wp10db, self.project, self.old_ns, self.old_article,
-      self.new_ns, self.new_article, self.dt)
+    logic_page.update_page_moved(self.wp10db, self.project, self.old_ns,
+                                 self.old_article, self.new_ns,
+                                 self.new_article, self.dt)
 
     with self.wp10db.cursor() as cursor:
-      cursor.execute('SELECT * FROM ' + Log.table_name + '''
+      cursor.execute(
+          'SELECT * FROM ' + Log.table_name + '''
         WHERE l_article = %(old_article)s
       ''', {'old_article': self.old_article})
       log = Log(**cursor.fetchone())
@@ -235,25 +286,25 @@ class LogicPageMoveDbTest(BaseWpOneDbTest):
     self.assertEqual(self.timestamp_db, log.l_revision_timestamp)
 
   def test_does_not_add_existing_move(self):
-    logic_page.update_page_moved(
-      self.wp10db, self.project, self.old_ns, self.old_article,
-      self.new_ns, self.new_article, self.dt)
+    logic_page.update_page_moved(self.wp10db, self.project, self.old_ns,
+                                 self.old_article, self.new_ns,
+                                 self.new_article, self.dt)
 
-    logic_page.update_page_moved(
-      self.wp10db, self.project, self.old_ns, self.old_article,
-      self.new_ns, self.new_article, self.dt)
+    logic_page.update_page_moved(self.wp10db, self.project, self.old_ns,
+                                 self.old_article, self.new_ns,
+                                 self.new_article, self.dt)
 
     all_moves = get_all_moves(self.wp10db)
     self.assertEqual(1, len(all_moves))
 
   def test_does_not_add_existing_log(self):
-    logic_page.update_page_moved(
-      self.wp10db, self.project, self.old_ns, self.old_article,
-      self.new_ns, self.new_article, self.dt)
+    logic_page.update_page_moved(self.wp10db, self.project, self.old_ns,
+                                 self.old_article, self.new_ns,
+                                 self.new_article, self.dt)
 
-    logic_page.update_page_moved(
-      self.wp10db, self.project, self.old_ns, self.old_article,
-      self.new_ns, self.new_article, self.dt)
+    logic_page.update_page_moved(self.wp10db, self.project, self.old_ns,
+                                 self.old_article, self.new_ns,
+                                 self.new_article, self.dt)
 
     all_logs = get_all_logs(self.wp10db)
     self.assertEqual(1, len(all_logs))

--- a/wp1/logic/project.py
+++ b/wp1/logic/project.py
@@ -73,7 +73,8 @@ def update_project_by_name(project_name):
 
 def update_global_articles_for_project_name(wp10db, project_name):
   with wp10db.cursor() as cursor:
-    cursor.execute('''
+    cursor.execute(
+        '''
       REPLACE INTO global_articles
       SELECT art, max(qrating), max(irating), max(score)
       FROM (
@@ -106,19 +107,19 @@ def update_global_articles_for_project_name(wp10db, project_name):
 
 
 def project_names_to_update(wikidb):
-  projects_in_root = logic_page.get_pages_by_category(
-    wikidb, ROOT_CATEGORY, CATEGORY_NS_INT)
+  projects_in_root = logic_page.get_pages_by_category(wikidb, ROOT_CATEGORY,
+                                                      CATEGORY_NS_INT)
   # List instead of iterate because the query will be reused in the processing
   # steps and if we don't exhaust it now, it will get truncated.
   for category_page in list(projects_in_root):
     if BY_QUALITY not in category_page.page_title:
       print('Skipping %s -- it does not have quality in title' %
-                    category_page.page_title.decode('utf-8'))
+            category_page.page_title.decode('utf-8'))
       continue
 
     if RE_REJECT_GENERIC.match(category_page.page_title):
       print('Skipping %r -- it is a generic "articles by quality"' %
-                    category_page)
+            category_page)
       continue
 
     yield category_page.base_title
@@ -127,7 +128,8 @@ def project_names_to_update(wikidb):
 def insert_or_update(wp10db, project):
   with wp10db.cursor() as cursor:
     logger.debug('Updating project: %r', project)
-    cursor.execute('UPDATE ' + Project.table_name + '''
+    cursor.execute(
+        'UPDATE ' + Project.table_name + '''
       SET p_timestamp=%(p_timestamp)s, p_wikipage=%(p_wikipage)s,
           p_parent=%(p_parent)s, p_shortname=%(p_shortname)s,
           p_count=%(p_count)s, p_qcount=%(p_qcount)s, p_icount=%(p_icount)s,
@@ -136,7 +138,8 @@ def insert_or_update(wp10db, project):
     ''', attr.asdict(project))
     if cursor.rowcount == 0:
       logger.debug('No project to update, inserting')
-      cursor.execute('INSERT INTO ' + Project.table_name + '''
+      cursor.execute(
+          'INSERT INTO ' + Project.table_name + '''
         (p_project, p_timestamp, p_wikipage, p_parent, p_shortname, p_count,
          p_qcount, p_icount, p_upload_timestamp, p_scope)
         VALUES (%(p_project)s, %(p_timestamp)s, %(p_wikipage)s, %(p_parent)s,
@@ -149,7 +152,8 @@ def insert_or_update(wp10db, project):
 
 def get_project_by_name(wp10db, project_name):
   with wp10db.cursor() as cursor:
-    cursor.execute('SELECT * FROM ' + Project.table_name + '''
+    cursor.execute(
+        'SELECT * FROM ' + Project.table_name + '''
       WHERE p_project=%(p_project)s
     ''', {'p_project': project_name})
     db_project = cursor.fetchone()
@@ -189,27 +193,29 @@ def update_category(wp10db, project, page, extra, kind, rating_to_category):
   if replaces is None:
     replaces = rating
 
-  category = Category(
-    c_project=project.p_project, c_type=kind.value.encode('utf-8'),
-    c_rating=rating.encode('utf-8'), c_category=page.page_title, c_ranking=ranking,
-    c_replacement=replaces.encode('utf-8'))
+  category = Category(c_project=project.p_project,
+                      c_type=kind.value.encode('utf-8'),
+                      c_rating=rating.encode('utf-8'),
+                      c_category=page.page_title,
+                      c_ranking=ranking,
+                      c_replacement=replaces.encode('utf-8'))
   # If there is an existing category, merge in our changes.
   logic_category.insert_or_update(wp10db, category)
 
 
-def update_project_categories_by_kind(
-    wikidb, wp10db, project, extra, kind):
+def update_project_categories_by_kind(wikidb, wp10db, project, extra, kind):
   logger.info('Updating project categories for %s', project.p_project)
   rating_to_category = {}
   category_name_main = logic_util.category_for_project_by_kind(
-    project.p_project, kind, category_prefix=False)
+      project.p_project, kind, category_prefix=False)
   category_name_alt = logic_util.category_for_project_by_kind(
-    project.p_project, kind, category_prefix=False, use_alt=True)
+      project.p_project, kind, category_prefix=False, use_alt=True)
 
   found_page = False
   for category_name in (category_name_main, category_name_alt):
-    for page in logic_page.get_pages_by_category(
-        wikidb, category_name, ns=CATEGORY_NS_INT):
+    for page in logic_page.get_pages_by_category(wikidb,
+                                                 category_name,
+                                                 ns=CATEGORY_NS_INT):
       found_page = True
       update_category(wp10db, project, page, extra, kind, rating_to_category)
 
@@ -224,27 +230,30 @@ def update_project_categories_by_kind(
 def update_project_assessments(wikidb, wp10db, project, extra_assessments):
   old_ratings = {}
   for rating in logic_rating.get_project_ratings(wp10db, project.p_project):
-    rating_ref = (
-      str(rating.r_namespace).encode('utf-8') + b':' + rating.r_article)
+    rating_ref = (str(rating.r_namespace).encode('utf-8') + b':' +
+                  rating.r_article)
     old_ratings[rating_ref] = rating
 
   seen = set()
   for kind in (AssessmentKind.QUALITY, AssessmentKind.IMPORTANCE):
     logger.debug('Updating %s assessments by %s',
                  project.p_project.decode('utf-8'), kind)
-    update_project_assessments_by_kind(
-      wikidb, wp10db, project, extra_assessments, kind, old_ratings, seen)
+    update_project_assessments_by_kind(wikidb, wp10db, project,
+                                       extra_assessments, kind, old_ratings,
+                                       seen)
 
   process_unseen_articles(wikidb, wp10db, project, old_ratings, seen)
 
-def update_project_assessments_by_kind(
-    wikidb, wp10db, project, extra_assessments, kind, old_ratings, seen):
+
+def update_project_assessments_by_kind(wikidb, wp10db, project,
+                                       extra_assessments, kind, old_ratings,
+                                       seen):
   if kind not in (AssessmentKind.QUALITY, AssessmentKind.IMPORTANCE):
     raise ValueError('Parameter "kind" was not one of QUALITY or IMPORTANCE')
 
   logger.info('Updating project %s assessments for %s', kind, project.p_project)
   rating_to_category = update_project_categories_by_kind(
-    wikidb, wp10db, project, extra_assessments, kind)
+      wikidb, wp10db, project, extra_assessments, kind)
 
   n = 0
   for current_rating, category in rating_to_category.items():
@@ -255,8 +264,8 @@ def update_project_assessments_by_kind(
       # Talk pages are tagged, we want the NS of the article itself.
       namespace = page.page_namespace - 1
       if not logic_util.is_namespace_acceptable(namespace):
-        logger.debug('Skipping %s with namespace=%s',
-                      page.page_title, namespace)
+        logger.debug('Skipping %s with namespace=%s', page.page_title,
+                     namespace)
         continue
 
       article_ref = str(namespace).encode('utf-8') + b':' + page.page_title
@@ -272,8 +281,10 @@ def update_project_assessments_by_kind(
         elif kind == AssessmentKind.IMPORTANCE:
           old_rating_value = rating.r_importance
       else:
-        rating = Rating(r_project=project.p_project, r_namespace=namespace,
-                        r_article=page.page_title, r_score=0)
+        rating = Rating(r_project=project.p_project,
+                        r_namespace=namespace,
+                        r_article=page.page_title,
+                        r_score=0)
         old_rating_value = NOT_A_CLASS.encode('utf-8')
 
       if kind == AssessmentKind.QUALITY:
@@ -286,15 +297,14 @@ def update_project_assessments_by_kind(
       if article_ref in old_ratings:
         if old_rating_value != current_rating:
           # If the article doesn't match its rating, update the logging table.
-          logic_rating.add_log_for_rating(
-              wp10db, rating, kind, old_rating_value)
+          logic_rating.add_log_for_rating(wp10db, rating, kind,
+                                          old_rating_value)
           # And update the rating of course.
           logic_rating.insert_or_update(wp10db, rating, kind)
       else:
         # Add the newly created rating.
         logic_rating.insert_or_update(wp10db, rating, kind)
-        logic_rating.add_log_for_rating(
-          wp10db, rating, kind, NOT_A_CLASS)
+        logic_rating.add_log_for_rating(wp10db, rating, kind, NOT_A_CLASS)
 
       n += 1
       if n >= MAX_ARTICLES_BEFORE_COMMIT:
@@ -307,7 +317,7 @@ def update_project_assessments_by_kind(
 
 def process_unseen_articles(wikidb, wp10db, project, old_ratings, seen):
   denom = len(old_ratings.keys())
-  ratio = len(seen)/denom if denom != 0 else 'NaN'
+  ratio = len(seen) / denom if denom != 0 else 'NaN'
 
   logger.debug('Looking for unseen articles, ratio was: %s', ratio)
   in_seen = 0
@@ -336,20 +346,23 @@ def process_unseen_articles(wikidb, wp10db, project, old_ratings, seen):
     ns = int(ns.encode('utf-8'))
     title = title.encode('utf-8')
 
-    move_data = logic_page.get_move_data(
-      wp10db, wikidb, ns, title, project.timestamp_dt)
+    move_data = logic_page.get_move_data(wp10db, wikidb, ns, title,
+                                         project.timestamp_dt)
     if move_data is not None:
-      logic_page.update_page_moved(
-        wp10db, project, ns, title, move_data['dest_ns'],
-        move_data['dest_title'], move_data['timestamp_dt'])
+      logic_page.update_page_moved(wp10db, project, ns, title,
+                                   move_data['dest_ns'],
+                                   move_data['dest_title'],
+                                   move_data['timestamp_dt'])
 
     # Mark this article as having NOT_A_CLASS for it's quality or importance.
     # This probably means the article was deleted, but could in fact mean that
     # we just failed to find its move data. Either way, the new article would
     # have already been picked up by the assessment updater, assuming it was
     # tagged correctly.
-    rating = Rating(
-      r_project=project.p_project, r_namespace=ns, r_article=title, r_score=0)
+    rating = Rating(r_project=project.p_project,
+                    r_namespace=ns,
+                    r_article=title,
+                    r_score=0)
     if kind in (AssessmentKind.QUALITY, AssessmentKind.BOTH):
       rating.quality = NOT_A_CLASS.encode('utf-8')
       if move_data:
@@ -366,11 +379,11 @@ def process_unseen_articles(wikidb, wp10db, project, old_ratings, seen):
     logic_rating.insert_or_update(wp10db, rating, kind)
 
     if kind in (AssessmentKind.QUALITY, AssessmentKind.BOTH):
-      logic_rating.add_log_for_rating(
-        wp10db, rating, AssessmentKind.QUALITY, old_rating.r_quality)
+      logic_rating.add_log_for_rating(wp10db, rating, AssessmentKind.QUALITY,
+                                      old_rating.r_quality)
     if kind in (AssessmentKind.IMPORTANCE, AssessmentKind.BOTH):
-      logic_rating.add_log_for_rating(
-        wp10db, rating, AssessmentKind.IMPORTANCE, old_rating.r_importance)
+      logic_rating.add_log_for_rating(wp10db, rating, AssessmentKind.IMPORTANCE,
+                                      old_rating.r_importance)
 
     n += 1
     if n >= MAX_ARTICLES_BEFORE_COMMIT:
@@ -380,31 +393,31 @@ def process_unseen_articles(wikidb, wp10db, project, old_ratings, seen):
   wp10db.ping()
   wp10db.commit()
 
-  logger.debug('SEEN REPORT:\nin seen: %s\nskipped: %s\nprocessed: %s',
-               in_seen, skipped, processed)
+  logger.debug('SEEN REPORT:\nin seen: %s\nskipped: %s\nprocessed: %s', in_seen,
+               skipped, processed)
 
 
 def cleanup_project(wp10db, project):
   # If both quality and importance are 'NotA-Class', that means the article
   # was once rated but isn't any more, so we delete the row
   count = logic_rating.delete_empty_for_project(wp10db, project)
-  logger.info('Deleted %s ratings that were empty for project: %s',
-              count, project.p_project.decode('utf-8'))
+  logger.info('Deleted %s ratings that were empty for project: %s', count,
+              project.p_project.decode('utf-8'))
 
-  # It's possible for the quality to be NULL if the article has a 
+  # It's possible for the quality to be NULL if the article has a
   # rated importance but no rated quality (not even Unassessed-Class).
-  # This will always happen if the article has a quality rating that the 
+  # This will always happen if the article has a quality rating that the
   # bot doesn't recognize. Change the NULL to sentinel value.
   count = logic_rating.update_null_quality_for_project(wp10db, project)
-  logger.info('Updated %s ratings, quality == NotAClass for project: %s',
-              count, project.p_project.decode('utf-8'))
+  logger.info('Updated %s ratings, quality == NotAClass for project: %s', count,
+              project.p_project.decode('utf-8'))
 
   # Finally, if a quality is assigned but not an importance, it is
-  # possible for the importance field to be null. Set it to 
+  # possible for the importance field to be null. Set it to
   # $NotAClass in this case.
   count = logic_rating.update_null_importance_for_project(wp10db, project)
   logger.info('Updated %s ratings, importance == NotAClass for project: %s',
-        count, project.p_project.decode('utf-8'))
+              count, project.p_project.decode('utf-8'))
 
 
 def update_project_record(wp10db, project, metadata):
@@ -413,12 +426,11 @@ def update_project_record(wp10db, project, metadata):
 
   num_ratings = logic_rating.count_for_project(wp10db, project)
 
-  n_quality = logic_rating.count_unassessed_quality_for_project(
-    wp10db, project)
+  n_quality = logic_rating.count_unassessed_quality_for_project(wp10db, project)
   quality_count = num_ratings - n_quality
 
   n_importance = logic_rating.count_unassessed_importance_for_project(
-    wp10db, project)
+      wp10db, project)
   importance_count = num_ratings - n_importance
 
   # Okay, update the fields of the project, warning if we're setting NULLs.
@@ -450,8 +462,8 @@ def update_project_record(wp10db, project, metadata):
 def update_project(wikidb, wp10db, project):
   extra_assessments = api_project.get_extra_assessments(project.p_project)
 
-  update_project_assessments(
-    wikidb, wp10db, project, extra_assessments['extra'])
+  update_project_assessments(wikidb, wp10db, project,
+                             extra_assessments['extra'])
 
   cleanup_project(wp10db, project)
 

--- a/wp1/logic/project_test.py
+++ b/wp1/logic/project_test.py
@@ -20,6 +20,7 @@ IMPORTANCE = config['IMPORTANCE']
 NOT_A_CLASS = config['NOT_A_CLASS']
 ROOT_CATEGORY = config['ROOT_CATEGORY']
 
+
 def _get_first_category(wp10db):
   with wp10db.cursor() as cursor:
     cursor.execute('SELECT * FROM ' + Category.table_name + ' LIMIT 1')
@@ -52,21 +53,24 @@ def _get_all_global_article_scores(wp10db):
 
 
 class UpdateCategoryTest(BaseWpOneDbTest):
+
   def setUp(self):
     super().setUp()
     self.project = Project(p_project=b'Test Project', p_timestamp=None)
     self.page = Page(page_title=b'A-Class Test articles',
-                     page_id=None, page_namespace=None)
+                     page_id=None,
+                     page_namespace=None)
     self.page_1 = Page(page_title=b'Mid-importance Test articles',
-                       page_id=None, page_namespace=None)
+                       page_id=None,
+                       page_namespace=None)
     self.page_2 = Page(page_title=b'Draft-Class Test articles',
-                       page_id=None, page_namespace=None)
+                       page_id=None,
+                       page_namespace=None)
 
   def test_quality_gets_updated(self):
     rating_to_category = {}
-    logic_project.update_category(
-      self.wp10db, self.project, self.page, {}, AssessmentKind.QUALITY,
-      rating_to_category)
+    logic_project.update_category(self.wp10db, self.project, self.page, {},
+                                  AssessmentKind.QUALITY, rating_to_category)
 
     category = _get_first_category(self.wp10db)
     self.assertEqual(self.page.page_title, rating_to_category['A-Class'])
@@ -79,10 +83,9 @@ class UpdateCategoryTest(BaseWpOneDbTest):
 
   def test_importance_gets_updated(self):
     rating_to_category = {}
-    logic_project.update_category(
-      self.wp10db, self.project, self.page_1, {}, AssessmentKind.IMPORTANCE,
-      rating_to_category)
-    
+    logic_project.update_category(self.wp10db, self.project, self.page_1, {},
+                                  AssessmentKind.IMPORTANCE, rating_to_category)
+
     category = _get_first_category(self.wp10db)
     self.assertEqual(self.page_1.page_title, rating_to_category['Mid-Class'])
     self.assertEqual(self.project.p_project, category.c_project)
@@ -95,18 +98,17 @@ class UpdateCategoryTest(BaseWpOneDbTest):
   def test_extra_category_gets_updated(self):
     rating_to_category = {}
     extra = {
-      'extra': {
-        self.page_2.page_title.decode('utf-8'): {
-          'title': 'Draft-Class',
-          'ranking': 10,
-          'replaces': 'Disambig-Class',
+        'extra': {
+            self.page_2.page_title.decode('utf-8'): {
+                'title': 'Draft-Class',
+                'ranking': 10,
+                'replaces': 'Disambig-Class',
+            }
         }
-      }
     }
-    logic_project.update_category(
-      self.wp10db, self.project, self.page_2, extra, AssessmentKind.QUALITY,
-      rating_to_category)
-    
+    logic_project.update_category(self.wp10db, self.project, self.page_2, extra,
+                                  AssessmentKind.QUALITY, rating_to_category)
+
     category = _get_first_category(self.wp10db)
     self.assertEqual(self.page_2.page_title, rating_to_category['Draft-Class'])
     self.assertEqual(self.project.p_project, category.c_project)
@@ -119,78 +121,90 @@ class UpdateCategoryTest(BaseWpOneDbTest):
   def test_skips_page_with_no_mapping_match(self):
     rating_to_category = {}
     page = Page(page_title=b'123*go', page_id=None, page_namespace=None)
-    logic_project.update_category(
-      self.wp10db, self.project, page, {}, AssessmentKind.QUALITY,
-      rating_to_category)
+    logic_project.update_category(self.wp10db, self.project, page, {},
+                                  AssessmentKind.QUALITY, rating_to_category)
 
     category = _get_first_category(self.wp10db)
     self.assertIsNone(category)
     self.assertEqual(0, len(rating_to_category))
-    
+
   def test_skips_page_with_no_class_match(self):
     rating_to_category = {}
-    page = Page(
-      page_title=b'Foo-Class Test articles', page_id=None, page_namespace=None)
-    logic_project.update_category(
-      self.wp10db, self.project, page, {}, AssessmentKind.QUALITY,
-      rating_to_category)
-    
+    page = Page(page_title=b'Foo-Class Test articles',
+                page_id=None,
+                page_namespace=None)
+    logic_project.update_category(self.wp10db, self.project, page, {},
+                                  AssessmentKind.QUALITY, rating_to_category)
+
     category = _get_first_category(self.wp10db)
     self.assertIsNone(category)
     self.assertEqual(0, len(rating_to_category))
+
 
 class UpdateProjectCategoriesByKindTest(BaseCombinedDbTest):
   quality_pages = (
-    (101, b'FA-Class_Test_articles', b'Test_articles_by_quality', b'FA-Class'),
-    (102, b'FL-Class_Test_articles', b'Test_articles_by_quality', b'FL-Class'),
-    (103, b'A-Class_Test_articles', b'Test_articles_by_quality', b'A-Class'),
-    (104, b'GA-Class_Test_articles', b'Test_articles_by_quality', b'GA-Class'),
-    (105, b'B-Class_Test_articles', b'Test_articles_by_quality', b'B-Class'),
-    (106, b'C-Class_Test_articles', b'Test_articles_by_quality', b'C-Class'),
+      (101, b'FA-Class_Test_articles', b'Test_articles_by_quality',
+       b'FA-Class'),
+      (102, b'FL-Class_Test_articles', b'Test_articles_by_quality',
+       b'FL-Class'),
+      (103, b'A-Class_Test_articles', b'Test_articles_by_quality', b'A-Class'),
+      (104, b'GA-Class_Test_articles', b'Test_articles_by_quality',
+       b'GA-Class'),
+      (105, b'B-Class_Test_articles', b'Test_articles_by_quality', b'B-Class'),
+      (106, b'C-Class_Test_articles', b'Test_articles_by_quality', b'C-Class'),
   )
 
   additional_junk_pages = (
-    (201, b'FA-Class_Foo_articles', b'Foo_articles_by_quality', b'FA-Class'),
-    (202, b'FL-Class_Bar_articles', b'Bar_articles_by_quality', b'FL-Class'),
-    (203, b'Mid-Class_Foo_articles', b'Foo_articles_by_importance',
-     b'Mid-Class'),
-    (204, b'Low-Class_Bar_articles', b'Bar_articles_by_importance',
-     b'Low-Class'),
+      (201, b'FA-Class_Foo_articles', b'Foo_articles_by_quality', b'FA-Class'),
+      (202, b'FL-Class_Bar_articles', b'Bar_articles_by_quality', b'FL-Class'),
+      (203, b'Mid-Class_Foo_articles', b'Foo_articles_by_importance',
+       b'Mid-Class'),
+      (204, b'Low-Class_Bar_articles', b'Bar_articles_by_importance',
+       b'Low-Class'),
   )
 
   importance_pages = (
-    (101, b'Top-Class_Test_articles', b'Test_articles_by_importance',
-     b'Top-Class'),
-    (102, b'High-Class_Test_articles', b'Test_articles_by_importance',
-     b'High-Class'),
-    (103, b'Mid-Class_Test_articles', b'Test_articles_by_importance',
-     b'Mid-Class'),
-    (104, b'Low-Class_Test_articles', b'Test_articles_by_importance',
-     b'Low-Class'),
+      (101, b'Top-Class_Test_articles', b'Test_articles_by_importance',
+       b'Top-Class'),
+      (102, b'High-Class_Test_articles', b'Test_articles_by_importance',
+       b'High-Class'),
+      (103, b'Mid-Class_Test_articles', b'Test_articles_by_importance',
+       b'Mid-Class'),
+      (104, b'Low-Class_Test_articles', b'Test_articles_by_importance',
+       b'Low-Class'),
   )
 
   priority_pages = (
-    (101, b'Top-Class_Test_articles', b'Test_articles_by_priority',
-     b'Top-Class'),
-    (102, b'High-Class_Test_articles', b'Test_articles_by_priority',
-     b'High-Class'),
-    (103, b'Mid-Class_Test_articles', b'Test_articles_by_priority',
-     b'Mid-Class'),
-    (104, b'Low-Class_Test_articles', b'Test_articles_by_priority',
-     b'Low-Class'),
+      (101, b'Top-Class_Test_articles', b'Test_articles_by_priority',
+       b'Top-Class'),
+      (102, b'High-Class_Test_articles', b'Test_articles_by_priority',
+       b'High-Class'),
+      (103, b'Mid-Class_Test_articles', b'Test_articles_by_priority',
+       b'Mid-Class'),
+      (104, b'Low-Class_Test_articles', b'Test_articles_by_priority',
+       b'Low-Class'),
   )
 
   def _insert_pages(self, pages):
     with self.wikidb.cursor() as cursor:
       for p in pages:
-        cursor.execute('''
+        cursor.execute(
+            '''
           INSERT INTO page (page_id, page_namespace, page_title)
           VALUES (%(id)s, %(ns)s, %(title)s)
-        ''', {'id': p[0], 'ns': 14, 'title': p[1]})
-        cursor.execute('''
+        ''', {
+                'id': p[0],
+                'ns': 14,
+                'title': p[1]
+            })
+        cursor.execute(
+            '''
           INSERT INTO categorylinks (cl_from, cl_to)
           VALUES (%(from)s, %(to)s)
-        ''', {'from': p[0], 'to': p[2]})
+        ''', {
+                'from': p[0],
+                'to': p[2]
+            })
 
   def setUp(self):
     super().setUp()
@@ -199,8 +213,9 @@ class UpdateProjectCategoriesByKindTest(BaseCombinedDbTest):
 
   def test_update_quality(self):
     self._insert_pages(self.quality_pages)
-    logic_project.update_project_categories_by_kind(
-      self.wikidb, self.wp10db, self.project, {}, AssessmentKind.QUALITY)
+    logic_project.update_project_categories_by_kind(self.wikidb, self.wp10db,
+                                                    self.project, {},
+                                                    AssessmentKind.QUALITY)
 
     categories = _get_all_categories(self.wp10db)
     self.assertNotEqual(0, len(categories))
@@ -222,15 +237,16 @@ class UpdateProjectCategoriesByKindTest(BaseCombinedDbTest):
   def test_update_quality_rating_to_category(self):
     self._insert_pages(self.quality_pages)
     rating_to_category = logic_project.update_project_categories_by_kind(
-      self.wikidb, self.wp10db, self.project, {}, AssessmentKind.QUALITY)
+        self.wikidb, self.wp10db, self.project, {}, AssessmentKind.QUALITY)
 
     expected = dict((p[3].decode('utf-8'), p[1]) for p in self.quality_pages)
     self.assertEqual(expected, rating_to_category)
 
   def test_update_importance(self):
     self._insert_pages(self.importance_pages)
-    logic_project.update_project_categories_by_kind(
-      self.wikidb, self.wp10db, self.project, {}, AssessmentKind.IMPORTANCE)
+    logic_project.update_project_categories_by_kind(self.wikidb, self.wp10db,
+                                                    self.project, {},
+                                                    AssessmentKind.IMPORTANCE)
 
     categories = _get_all_categories(self.wp10db)
     self.assertNotEqual(0, len(categories))
@@ -251,8 +267,9 @@ class UpdateProjectCategoriesByKindTest(BaseCombinedDbTest):
 
   def test_update_priority(self):
     self._insert_pages(self.priority_pages)
-    logic_project.update_project_categories_by_kind(
-      self.wikidb, self.wp10db, self.project, {}, AssessmentKind.IMPORTANCE)
+    logic_project.update_project_categories_by_kind(self.wikidb, self.wp10db,
+                                                    self.project, {},
+                                                    AssessmentKind.IMPORTANCE)
 
     categories = _get_all_categories(self.wp10db)
     self.assertNotEqual(0, len(categories))
@@ -271,107 +288,121 @@ class UpdateProjectCategoriesByKindTest(BaseCombinedDbTest):
     category_replaces = set(category.c_replacement for category in categories)
     self.assertEqual(expected_ratings, category_replaces)
 
+
 class ArticlesTest(BaseCombinedDbTest):
   old_ts_wiki = b'2018-07-04T05:05:05Z'
   expected_ts_wiki = b'2018-12-25T11:22:33Z'
 
   global_article_scores = [
-    (225, 100, 475),
-    (150, 0, 625),
-    (100, 100, 229),
-    (150, 100, 589),
-    (150, 200, 596),
-    (150, 100, 398),
-    (0, 0, 109),
-    (225, 100, 434),
-    (150, 300, 629),
-    (150, 300, 629),
-    (150, 300, 629),
-    (100, 100, 461),
-    (225, 0, 288),
-    (0, 0, 35),
-    (150, 100, 665),
-    (150, 100, 527),
-    (100,0, 176),
-    (150, 100, 37),
-    (15, 100, 279),
-    (150, 100, 279),
-    (100, 100, 415),
+      (225, 100, 475),
+      (150, 0, 625),
+      (100, 100, 229),
+      (150, 100, 589),
+      (150, 200, 596),
+      (150, 100, 398),
+      (0, 0, 109),
+      (225, 100, 434),
+      (150, 300, 629),
+      (150, 300, 629),
+      (150, 300, 629),
+      (100, 100, 461),
+      (225, 0, 288),
+      (0, 0, 35),
+      (150, 100, 665),
+      (150, 100, 527),
+      (100, 0, 176),
+      (150, 100, 37),
+      (15, 100, 279),
+      (150, 100, 279),
+      (100, 100, 415),
   ]
 
   quality_pages = (
-    (101, b'FA-Class_Test_articles', b'Test_articles_by_quality', None, 14),
-    (102, b'FL-Class_Test_articles', b'Test_articles_by_quality', None, 14),
-    (103, b'GA-Class_Test_articles', b'Test_articles_by_quality', None, 14),
-    (104, b'A-Class_Test_articles', b'Test_articles_by_quality', None, 14),
-    (105, b'B-Class_Test_articles', b'Test_articles_by_quality', None, 14),
-    (106, b'C-Class_Test_articles', b'Test_articles_by_quality', None, 14),
-    (201, b'Art of testing', b'FA-Class_Test_articles', b'FA-Class', 1),
-    (202, b'Testing mechanics', b'FA-Class_Test_articles', b'FA-Class', 1),
-    (203, b'Rules of testing', b'FA-Class_Test_articles', b'FA-Class', 1),
-    (210, b'Test practices', b'FL-Class_Test_articles', b'FL-Class', 1),
-    (211, b'Testing history', b'FL-Class_Test_articles', b'FL-Class', 1),
-    (212, b'Test frameworks', b'FL-Class_Test_articles', b'FL-Class', 1),
-    (220, b'Testing figures', b'A-Class_Test_articles', b'A-Class', 1),
-    (221, b'Important tests', b'A-Class_Test_articles', b'A-Class', 1),
-    (222, b'Test results', b'A-Class_Test_articles', b'A-Class', 1),
-    (230, b'Test main inheritance', b'GA-Class_Test_articles', b'GA-Class', 1),
-    (231, b'Test sub inheritance', b'GA-Class_Test_articles', b'GA-Class', 1),
-    (232, b'Test other inheritance', b'GA-Class_Test_articles', b'GA-Class',
-     1),
-    (240, b'Testing best practices', b'B-Class_Test_articles', b'B-Class', 1),
-    (241, b'Testing tools', b'B-Class_Test_articles', b'B-Class', 1),
-    (242, b'Operation of tests', b'B-Class_Test_articles', b'B-Class', 1),
-    (250, b'Lesser-known tests', b'C-Class_Test_articles', b'C-Class', 1),
-    (251, b'Failures of tests', b'C-Class_Test_articles', b'C-Class', 1),
-    (252, b'How to test', b'C-Class_Test_articles', b'C-Class', 1),
+      (101, b'FA-Class_Test_articles', b'Test_articles_by_quality', None, 14),
+      (102, b'FL-Class_Test_articles', b'Test_articles_by_quality', None, 14),
+      (103, b'GA-Class_Test_articles', b'Test_articles_by_quality', None, 14),
+      (104, b'A-Class_Test_articles', b'Test_articles_by_quality', None, 14),
+      (105, b'B-Class_Test_articles', b'Test_articles_by_quality', None, 14),
+      (106, b'C-Class_Test_articles', b'Test_articles_by_quality', None, 14),
+      (201, b'Art of testing', b'FA-Class_Test_articles', b'FA-Class', 1),
+      (202, b'Testing mechanics', b'FA-Class_Test_articles', b'FA-Class', 1),
+      (203, b'Rules of testing', b'FA-Class_Test_articles', b'FA-Class', 1),
+      (210, b'Test practices', b'FL-Class_Test_articles', b'FL-Class', 1),
+      (211, b'Testing history', b'FL-Class_Test_articles', b'FL-Class', 1),
+      (212, b'Test frameworks', b'FL-Class_Test_articles', b'FL-Class', 1),
+      (220, b'Testing figures', b'A-Class_Test_articles', b'A-Class', 1),
+      (221, b'Important tests', b'A-Class_Test_articles', b'A-Class', 1),
+      (222, b'Test results', b'A-Class_Test_articles', b'A-Class', 1),
+      (230, b'Test main inheritance', b'GA-Class_Test_articles', b'GA-Class',
+       1),
+      (231, b'Test sub inheritance', b'GA-Class_Test_articles', b'GA-Class', 1),
+      (232, b'Test other inheritance', b'GA-Class_Test_articles', b'GA-Class',
+       1),
+      (240, b'Testing best practices', b'B-Class_Test_articles', b'B-Class', 1),
+      (241, b'Testing tools', b'B-Class_Test_articles', b'B-Class', 1),
+      (242, b'Operation of tests', b'B-Class_Test_articles', b'B-Class', 1),
+      (250, b'Lesser-known tests', b'C-Class_Test_articles', b'C-Class', 1),
+      (251, b'Failures of tests', b'C-Class_Test_articles', b'C-Class', 1),
+      (252, b'How to test', b'C-Class_Test_articles', b'C-Class', 1),
   )
 
   importance_pages = (
-    (1010, b'Top-Class_Test_articles', b'Test_articles_by_importance', None,
-     14),
-    (1020, b'High-Class_Test_articles', b'Test_articles_by_importance', None,
-     14),
-    (1030, b'Mid-Class_Test_articles', b'Test_articles_by_importance', None,
-     14),
-    (1040, b'Low-Class_Test_articles', b'Test_articles_by_importance', None,
-     14),
-    (2010, b'Art of testing', b'Top-Class_Test_articles', b'Top-Class', 1),
-    (2020, b'Testing mechanics', b'Top-Class_Test_articles', b'Top-Class', 1),
-    (2030, b'Rules of testing', b'Top-Class_Test_articles', b'Top-Class', 1),
-    (2040, b'Test practices', b'Top-Class_Test_articles', b'Top-Class', 1),
-    (2110, b'Testing history', b'High-Class_Test_articles', b'High-Class', 1),
-    (2120, b'Test frameworks', b'High-Class_Test_articles', b'High-Class', 1),
-    (2200, b'Testing figures', b'High-Class_Test_articles', b'High-Class', 1),
-    (2210, b'Important tests', b'High-Class_Test_articles', b'High-Class', 1),
-    (2220, b'Test results', b'Mid-Class_Test_articles', b'Mid-Class', 1),
-    (2300, b'Test main inheritance', b'Mid-Class_Test_articles', b'Mid-Class',
-     1),
-    (2310, b'Test sub inheritance', b'Mid-Class_Test_articles', b'Mid-Class',
-     1),
-    (2320, b'Test other inheritance', b'Mid-Class_Test_articles', b'Mid-Class',
-     1),
-    (2400, b'Testing best practices', b'Low-Class_Test_articles', b'Low-Class',
-     1),
-    (2410, b'Testing tools', b'Low-Class_Test_articles', b'Low-Class', 1),
-    (2420, b'Operation of tests', b'Low-Class_Test_articles', b'Low-Class', 1),
-    (2500, b'Lesser-known tests', b'Low-Class_Test_articles', b'Low-Class', 1),
-    (2510, b'Failures of tests', b'Low-Class_Test_articles', b'Low-Class', 1),
-    (2520, b'How to test', b'Low-Class_Test_articles', b'Low-Class', 1),
+      (1010, b'Top-Class_Test_articles', b'Test_articles_by_importance', None,
+       14),
+      (1020, b'High-Class_Test_articles', b'Test_articles_by_importance', None,
+       14),
+      (1030, b'Mid-Class_Test_articles', b'Test_articles_by_importance', None,
+       14),
+      (1040, b'Low-Class_Test_articles', b'Test_articles_by_importance', None,
+       14),
+      (2010, b'Art of testing', b'Top-Class_Test_articles', b'Top-Class', 1),
+      (2020, b'Testing mechanics', b'Top-Class_Test_articles', b'Top-Class', 1),
+      (2030, b'Rules of testing', b'Top-Class_Test_articles', b'Top-Class', 1),
+      (2040, b'Test practices', b'Top-Class_Test_articles', b'Top-Class', 1),
+      (2110, b'Testing history', b'High-Class_Test_articles', b'High-Class', 1),
+      (2120, b'Test frameworks', b'High-Class_Test_articles', b'High-Class', 1),
+      (2200, b'Testing figures', b'High-Class_Test_articles', b'High-Class', 1),
+      (2210, b'Important tests', b'High-Class_Test_articles', b'High-Class', 1),
+      (2220, b'Test results', b'Mid-Class_Test_articles', b'Mid-Class', 1),
+      (2300, b'Test main inheritance', b'Mid-Class_Test_articles', b'Mid-Class',
+       1),
+      (2310, b'Test sub inheritance', b'Mid-Class_Test_articles', b'Mid-Class',
+       1),
+      (2320, b'Test other inheritance', b'Mid-Class_Test_articles',
+       b'Mid-Class', 1),
+      (2400, b'Testing best practices', b'Low-Class_Test_articles',
+       b'Low-Class', 1),
+      (2410, b'Testing tools', b'Low-Class_Test_articles', b'Low-Class', 1),
+      (2420, b'Operation of tests', b'Low-Class_Test_articles', b'Low-Class',
+       1),
+      (2500, b'Lesser-known tests', b'Low-Class_Test_articles', b'Low-Class',
+       1),
+      (2510, b'Failures of tests', b'Low-Class_Test_articles', b'Low-Class', 1),
+      (2520, b'How to test', b'Low-Class_Test_articles', b'Low-Class', 1),
   )
 
   def _insert_pages(self, pages):
     ts = datetime(2018, 12, 25, 11, 22, 33)
     with self.wikidb.cursor() as cursor:
       for p in pages:
-        cursor.execute('''
+        cursor.execute(
+            '''
           INSERT INTO page (page_id, page_namespace, page_title)
           VALUES (%(id)s, %(ns)s, %(title)s)
-        ''', {'id': p[0], 'ns': p[4], 'title': p[1]})
-        cursor.execute('''
+        ''', {
+                'id': p[0],
+                'ns': p[4],
+                'title': p[1]
+            })
+        cursor.execute(
+            '''
           INSERT INTO categorylinks (cl_from, cl_to, cl_timestamp)
           VALUES (%(from)s, %(to)s, %(ts)s)
-        ''', {'from': p[0], 'to': p[2], 'ts': ts})
+        ''', {
+                'from': p[0],
+                'to': p[2],
+                'ts': ts
+            })
     self.wikidb.commit()
 
   def _insert_ratings(self, pages, namespace, kind, override_rating=None):
@@ -384,8 +415,9 @@ class ArticlesTest(BaseCombinedDbTest):
         art = p[1]
       if override_rating is not None:
         r = override_rating
-      rating = Rating(
-        r_project=self.project.p_project, r_namespace=namespace, r_article=art)
+      rating = Rating(r_project=self.project.p_project,
+                      r_namespace=namespace,
+                      r_article=art)
       if kind == AssessmentKind.QUALITY or kind == 'both':
         if isinstance(r, tuple):
           rating.r_quality = r[0]
@@ -400,7 +432,8 @@ class ArticlesTest(BaseCombinedDbTest):
         rating.r_importance_timestamp = self.old_ts_wiki
 
       with self.wp10db.cursor() as cursor:
-        cursor.execute('INSERT INTO ' + Rating.table_name + '''
+        cursor.execute(
+            'INSERT INTO ' + Rating.table_name + '''
           (r_project, r_namespace, r_article, r_score, r_quality,
            r_quality_timestamp, r_importance, r_importance_timestamp)
           VALUES (%(r_project)s, %(r_namespace)s, %(r_article)s, %(r_score)s,
@@ -410,10 +443,11 @@ class ArticlesTest(BaseCombinedDbTest):
       self.wp10db.commit()
 
   def _insert_global_scores(self):
-    article_scores = [(art[1],) + score
-    for score, art in zip(self.global_article_scores, self.quality_pages[6:])]
+    article_scores = [(art[1],) + score for score, art in zip(
+        self.global_article_scores, self.quality_pages[6:])]
     with self.wp10db.cursor() as cursor:
-      cursor.executemany('''
+      cursor.executemany(
+          '''
         INSERT INTO global_articles
           (a_article, a_quality, a_importance, a_score)
         VALUES (%s, %s, %s, %s)
@@ -424,7 +458,9 @@ class ArticlesTest(BaseCombinedDbTest):
     super().setUp()
     self.project = Project(p_project=b'Test', p_timestamp=b'20100101000000')
 
+
 class UpdateProjectAssessmentsTest(ArticlesTest):
+
   def setUp(self):
     super().setUp()
 
@@ -434,22 +470,28 @@ class UpdateProjectAssessmentsTest(ArticlesTest):
     self.expected_dt = datetime.strptime(self.timestamp_str, TS_FORMAT)
 
     self.api_return = {
-      'query': {
-        'redirects': [{'to': self.expected_title}],
-        'pages': {123: {
-          'ns': self.expected_ns,
-          'title': self.expected_title,
-          'revisions': [{'timestamp': self.timestamp_str}],
-        }},
-      },
+        'query': {
+            'redirects': [{
+                'to': self.expected_title
+            }],
+            'pages': {
+                123: {
+                    'ns': self.expected_ns,
+                    'title': self.expected_title,
+                    'revisions': [{
+                        'timestamp': self.timestamp_str
+                    }],
+                }
+            },
+        },
     }
 
   def test_old_rating_same_quality(self):
     self._insert_pages(self.quality_pages)
     self._insert_ratings(self.quality_pages[6:], 0, AssessmentKind.QUALITY)
 
-    logic_project.update_project_assessments(
-      self.wikidb, self.wp10db, self.project, {})
+    logic_project.update_project_assessments(self.wikidb, self.wp10db,
+                                             self.project, {})
 
     ratings = _get_all_ratings(self.wp10db)
     self.assertNotEqual(0, len(ratings))
@@ -465,11 +507,11 @@ class UpdateProjectAssessmentsTest(ArticlesTest):
 
   def test_old_rating_same_importance(self):
     self._insert_pages(self.importance_pages)
-    self._insert_ratings(
-      self.importance_pages[4:], 0, AssessmentKind.IMPORTANCE)
+    self._insert_ratings(self.importance_pages[4:], 0,
+                         AssessmentKind.IMPORTANCE)
 
-    logic_project.update_project_assessments(
-      self.wikidb, self.wp10db, self.project, {})
+    logic_project.update_project_assessments(self.wikidb, self.wp10db,
+                                             self.project, {})
 
     ratings = _get_all_ratings(self.wp10db)
     self.assertNotEqual(0, len(ratings))
@@ -485,12 +527,13 @@ class UpdateProjectAssessmentsTest(ArticlesTest):
 
   def test_old_rating_update_quality(self):
     self._insert_pages(self.quality_pages)
-    self._insert_ratings(
-      self.quality_pages[6:], 0, AssessmentKind.QUALITY,
-      override_rating=NOT_A_CLASS.encode('utf-8'))
+    self._insert_ratings(self.quality_pages[6:],
+                         0,
+                         AssessmentKind.QUALITY,
+                         override_rating=NOT_A_CLASS.encode('utf-8'))
 
-    logic_project.update_project_assessments(
-      self.wikidb, self.wp10db, self.project, {})
+    logic_project.update_project_assessments(self.wikidb, self.wp10db,
+                                             self.project, {})
 
     ratings = _get_all_ratings(self.wp10db)
     self.assertNotEqual(0, len(ratings))
@@ -506,12 +549,13 @@ class UpdateProjectAssessmentsTest(ArticlesTest):
 
   def test_old_rating_update_importance(self):
     self._insert_pages(self.importance_pages)
-    self._insert_ratings(
-      self.importance_pages[4:], 0, AssessmentKind.IMPORTANCE,
-      override_rating=NOT_A_CLASS.encode('utf-8'))
+    self._insert_ratings(self.importance_pages[4:],
+                         0,
+                         AssessmentKind.IMPORTANCE,
+                         override_rating=NOT_A_CLASS.encode('utf-8'))
 
-    logic_project.update_project_assessments(
-      self.wikidb, self.wp10db, self.project, {})
+    logic_project.update_project_assessments(self.wikidb, self.wp10db,
+                                             self.project, {})
 
     ratings = _get_all_ratings(self.wp10db)
     self.assertNotEqual(0, len(ratings))
@@ -528,12 +572,13 @@ class UpdateProjectAssessmentsTest(ArticlesTest):
   def test_old_rating_update_both(self):
     self._insert_pages(self.quality_pages)
     self._insert_pages(self.importance_pages)
-    self._insert_ratings(
-      self.quality_pages[6:], 0, 'both',
-      override_rating=NOT_A_CLASS.encode('utf-8'))
+    self._insert_ratings(self.quality_pages[6:],
+                         0,
+                         'both',
+                         override_rating=NOT_A_CLASS.encode('utf-8'))
 
-    logic_project.update_project_assessments(
-      self.wikidb, self.wp10db, self.project, {})
+    logic_project.update_project_assessments(self.wikidb, self.wp10db,
+                                             self.project, {})
 
     ratings = _get_all_ratings(self.wp10db)
     self.assertNotEqual(0, len(ratings))
@@ -555,8 +600,8 @@ class UpdateProjectAssessmentsTest(ArticlesTest):
 
     expected_global_ts = b'20190113000000'
     with patch('wp1.logic.rating.GLOBAL_TIMESTAMP', expected_global_ts):
-      logic_project.update_project_assessments(
-        self.wikidb, self.wp10db, self.project, {})
+      logic_project.update_project_assessments(self.wikidb, self.wp10db,
+                                               self.project, {})
 
     ratings = _get_all_ratings(self.wp10db)
     self.assertNotEqual(0, len(ratings))
@@ -589,8 +634,8 @@ class UpdateProjectAssessmentsTest(ArticlesTest):
 
     expected_global_ts = b'20190113000000'
     with patch('wp1.logic.rating.GLOBAL_TIMESTAMP', expected_global_ts):
-      logic_project.update_project_assessments(
-        self.wikidb, self.wp10db, self.project, {})
+      logic_project.update_project_assessments(self.wikidb, self.wp10db,
+                                               self.project, {})
 
     ratings = _get_all_ratings(self.wp10db)
     self.assertNotEqual(0, len(ratings))
@@ -624,8 +669,8 @@ class UpdateProjectAssessmentsTest(ArticlesTest):
 
     expected_global_ts = b'20190113000000'
     with patch('wp1.logic.rating.GLOBAL_TIMESTAMP', expected_global_ts):
-      logic_project.update_project_assessments(
-        self.wikidb, self.wp10db, self.project, {})
+      logic_project.update_project_assessments(self.wikidb, self.wp10db,
+                                               self.project, {})
 
     ratings = _get_all_ratings(self.wp10db)
     self.assertNotEqual(0, len(ratings))
@@ -658,10 +703,11 @@ class UpdateProjectAssessmentsTest(ArticlesTest):
       if kwargs['titles'] == ':How to test':
         return self.api_return
       return {}
+
     patched_site.api.side_effect = fake_api
 
-    logic_project.update_project_assessments(
-      self.wikidb, self.wp10db, self.project, {})
+    logic_project.update_project_assessments(self.wikidb, self.wp10db,
+                                             self.project, {})
 
     self.assertEqual(2, len(patched_site.api.call_args_list))
 
@@ -683,17 +729,18 @@ class UpdateProjectAssessmentsTest(ArticlesTest):
   @patch('wp1.logic.api.page.site')
   def test_not_seen_importance(self, patched_site):
     self._insert_pages(self.importance_pages[:-2])
-    self._insert_ratings(
-      self.importance_pages[4:], 0, AssessmentKind.IMPORTANCE)
+    self._insert_ratings(self.importance_pages[4:], 0,
+                         AssessmentKind.IMPORTANCE)
 
     def fake_api(*args, **kwargs):
       if kwargs['titles'] == ':How to test':
         return self.api_return
       return {}
+
     patched_site.api.side_effect = fake_api
 
-    logic_project.update_project_assessments(
-      self.wikidb, self.wp10db, self.project, {})
+    logic_project.update_project_assessments(self.wikidb, self.wp10db,
+                                             self.project, {})
 
     self.assertEqual(2, len(patched_site.api.call_args_list))
 
@@ -712,40 +759,46 @@ class UpdateProjectAssessmentsTest(ArticlesTest):
       else:
         self.assertEqual(page_to_rating[r.r_article], r.r_importance, repr(r))
 
-
   @patch('wp1.logic.api.page.site')
   def test_not_seen_null_quality(self, patched_site):
     self._insert_pages(self.quality_pages)
-    self._insert_ratings(self.quality_pages[6:], 0, AssessmentKind.QUALITY,
+    self._insert_ratings(self.quality_pages[6:],
+                         0,
+                         AssessmentKind.QUALITY,
                          override_rating=None)
 
     def fake_api(*args, **kwargs):
       if kwargs['titles'] == ':How to test':
         return self.api_return
       return {}
+
     patched_site.api.side_effect = fake_api
 
-    logic_project.update_project_assessments(
-      self.wikidb, self.wp10db, self.project, {})
+    logic_project.update_project_assessments(self.wikidb, self.wp10db,
+                                             self.project, {})
 
     patched_site.assert_not_called()
 
   @patch('wp1.logic.api.page.site')
   def test_not_seen_null_importance(self, patched_site):
     self._insert_pages(self.importance_pages)
-    self._insert_ratings(self.importance_pages[6:], 0,
-                         AssessmentKind.IMPORTANCE, override_rating=None)
+    self._insert_ratings(self.importance_pages[6:],
+                         0,
+                         AssessmentKind.IMPORTANCE,
+                         override_rating=None)
 
     def fake_api(*args, **kwargs):
       if kwargs['titles'] == ':How to test':
         return self.api_return
       return {}
+
     patched_site.api.side_effect = fake_api
 
-    logic_project.update_project_assessments(
-      self.wikidb, self.wp10db, self.project, {})
+    logic_project.update_project_assessments(self.wikidb, self.wp10db,
+                                             self.project, {})
 
     patched_site.assert_not_called()
+
 
 class GlobalArticlesTest(ArticlesTest):
 
@@ -759,105 +812,122 @@ class GlobalArticlesTest(ArticlesTest):
     self._insert_global_scores()
 
   def test_update_global_articles_table(self):
-    expected = [
-      {'a_article': b'Art of testing',
-       'a_importance': b'400',
-       'a_quality': b'500',
-       'a_score': 475},
-      {'a_article': b'Failures of tests',
-       'a_importance': b'100',
-       'a_quality': b'225',
-       'a_score': 176},
-      {'a_article': b'How to test',
-       'a_importance': b'100',
-       'a_quality': b'225',
-       'a_score': 37},
-      {'a_article': b'Important tests',
-       'a_importance': b'300',
-       'a_quality': b'425',
-       'a_score': 434},
-      {'a_article': b'Lesser-known tests',
-       'a_importance': b'100',
-       'a_quality': b'225',
-       'a_score': 527},
-      {'a_article': b'Operation of tests',
-       'a_importance': b'100',
-       'a_quality': b'300',
-       'a_score': 665},
-      {'a_article': b'Rules of testing',
-       'a_importance': b'400',
-       'a_quality': b'500',
-       'a_score': 229},
-      {'a_article': b'Test frameworks',
-       'a_importance': b'300',
-       'a_quality': b'480',
-       'a_score': 398},
-      {'a_article': b'Test main inheritance',
-       'a_importance': b'300',
-       'a_quality': b'400',
-       'a_score': 629},
-      {'a_article': b'Test other inheritance',
-       'a_importance': b'200',
-       'a_quality': b'400',
-       'a_score': 461},
-      {'a_article': b'Test practices',
-       'a_importance': b'400',
-       'a_quality': b'480',
-       'a_score': 589},
-      {'a_article': b'Test results',
-       'a_importance': b'300',
-       'a_quality': b'425',
-       'a_score': 629},
-      {'a_article': b'Test sub inheritance',
-       'a_importance': b'300',
-       'a_quality': b'400',
-       'a_score': 629},
-      {'a_article': b'Testing best practices',
-       'a_importance': b'100',
-       'a_quality': b'300',
-       'a_score': 288},
-      {'a_article': b'Testing figures',
-       'a_importance': b'300',
-       'a_quality': b'425',
-       'a_score': 109},
-      {'a_article': b'Testing history',
-       'a_importance': b'300',
-       'a_quality': b'480',
-       'a_score': 596},
-      {'a_article': b'Testing mechanics',
-       'a_importance': b'400',
-       'a_quality': b'500',
-       'a_score': 625},
-      {'a_article': b'Testing tools',
-       'a_importance': b'100',
-       'a_quality': b'300',
-       'a_score': 35}
-    ]
+    expected = [{
+        'a_article': b'Art of testing',
+        'a_importance': b'400',
+        'a_quality': b'500',
+        'a_score': 475
+    }, {
+        'a_article': b'Failures of tests',
+        'a_importance': b'100',
+        'a_quality': b'225',
+        'a_score': 176
+    }, {
+        'a_article': b'How to test',
+        'a_importance': b'100',
+        'a_quality': b'225',
+        'a_score': 37
+    }, {
+        'a_article': b'Important tests',
+        'a_importance': b'300',
+        'a_quality': b'425',
+        'a_score': 434
+    }, {
+        'a_article': b'Lesser-known tests',
+        'a_importance': b'100',
+        'a_quality': b'225',
+        'a_score': 527
+    }, {
+        'a_article': b'Operation of tests',
+        'a_importance': b'100',
+        'a_quality': b'300',
+        'a_score': 665
+    }, {
+        'a_article': b'Rules of testing',
+        'a_importance': b'400',
+        'a_quality': b'500',
+        'a_score': 229
+    }, {
+        'a_article': b'Test frameworks',
+        'a_importance': b'300',
+        'a_quality': b'480',
+        'a_score': 398
+    }, {
+        'a_article': b'Test main inheritance',
+        'a_importance': b'300',
+        'a_quality': b'400',
+        'a_score': 629
+    }, {
+        'a_article': b'Test other inheritance',
+        'a_importance': b'200',
+        'a_quality': b'400',
+        'a_score': 461
+    }, {
+        'a_article': b'Test practices',
+        'a_importance': b'400',
+        'a_quality': b'480',
+        'a_score': 589
+    }, {
+        'a_article': b'Test results',
+        'a_importance': b'300',
+        'a_quality': b'425',
+        'a_score': 629
+    }, {
+        'a_article': b'Test sub inheritance',
+        'a_importance': b'300',
+        'a_quality': b'400',
+        'a_score': 629
+    }, {
+        'a_article': b'Testing best practices',
+        'a_importance': b'100',
+        'a_quality': b'300',
+        'a_score': 288
+    }, {
+        'a_article': b'Testing figures',
+        'a_importance': b'300',
+        'a_quality': b'425',
+        'a_score': 109
+    }, {
+        'a_article': b'Testing history',
+        'a_importance': b'300',
+        'a_quality': b'480',
+        'a_score': 596
+    }, {
+        'a_article': b'Testing mechanics',
+        'a_importance': b'400',
+        'a_quality': b'500',
+        'a_score': 625
+    }, {
+        'a_article': b'Testing tools',
+        'a_importance': b'100',
+        'a_quality': b'300',
+        'a_score': 35
+    }]
 
-    logic_project.update_project(
-      self.wikidb, self.wp10db, self.project)
+    logic_project.update_project(self.wikidb, self.wp10db, self.project)
     logic_project.update_global_articles_for_project_name(
-      self.wp10db, self.project.p_project)
+        self.wp10db, self.project.p_project)
 
     actual = _get_all_global_article_scores(self.wp10db)
     actual = sorted(sorted(list(a.items())) for a in actual)
     expected = sorted(sorted(list(e.items())) for e in expected)
     self.assertEqual(expected, actual)
 
+
 class CleanupProjectTest(BaseWpOneDbTest):
   ratings = (
-    (b'Art of testing', b'FA-Class', b'High-Class'),
-    (b'Testing mechanics', b'FA-Class', b'Mid-Class'),
-    (b'Rules of testing',  b'FA-Class', b'NotA-Class'),
-    (b'Test frameworks', b'NotA-Class', b'Mid-Class'),
-    (b'Test practices', b'FL-Class', None),
-    (b'Testing history', b'FL-Class', None),
-    (b'Testing figures', None, b'Low-Class'),
-    (b'Important tests', None, b'Low-Class'),
-    (b'Test results', b'NotA-Class', b'NotA-Class'),
-    (b'Test main inheritance', b'NotA-Class', b'NotA-Class'),
-    (b'Failures of tests', None, None),
-    (b'How to test', None, None),
+      (b'Art of testing', b'FA-Class', b'High-Class'),
+      (b'Testing mechanics', b'FA-Class', b'Mid-Class'),
+      (b'Rules of testing', b'FA-Class', b'NotA-Class'),
+      (b'Test frameworks', b'NotA-Class', b'Mid-Class'),
+      (b'Test practices', b'FL-Class', None),
+      (b'Testing history', b'FL-Class', None),
+      (b'Testing figures', None, b'Low-Class'),
+      (b'Important tests', None, b'Low-Class'),
+      (b'Test results', b'NotA-Class', b'NotA-Class'),
+      (b'Test main inheritance', b'NotA-Class', b'NotA-Class'),
+      (b'Failures of tests', None, None),
+      (b'How to test', None, None),
   )
   not_a_class_db = NOT_A_CLASS.encode('utf-8')
 
@@ -868,12 +938,16 @@ class CleanupProjectTest(BaseWpOneDbTest):
     qual_ts = b'2018-04-01T12:30:00Z'
     imp_ts = b'2018-05-01T13:45:10Z'
     with self.wp10db.cursor() as cursor:
-      for r in self.ratings:      
-        rating = Rating(r_project=self.project.p_project, r_namespace=0,
-                        r_article=r[0], r_quality=r[1], r_importance=r[2],
+      for r in self.ratings:
+        rating = Rating(r_project=self.project.p_project,
+                        r_namespace=0,
+                        r_article=r[0],
+                        r_quality=r[1],
+                        r_importance=r[2],
                         r_quality_timestamp=qual_ts,
                         r_importance_timestamp=imp_ts)
-        cursor.execute('INSERT INTO ' + Rating.table_name + '''
+        cursor.execute(
+            'INSERT INTO ' + Rating.table_name + '''
           (r_project, r_namespace, r_article, r_score, r_quality,
            r_quality_timestamp, r_importance, r_importance_timestamp)
           VALUES (%(r_project)s, %(r_namespace)s, %(r_article)s, %(r_score)s,
@@ -882,7 +956,7 @@ class CleanupProjectTest(BaseWpOneDbTest):
         ''', attr.asdict(rating))
     self.wp10db.commit()
 
-    logic_project.cleanup_project(self.wp10db, self.project)    
+    logic_project.cleanup_project(self.wp10db, self.project)
 
   def test_deletes_empty(self):
     ratings = _get_all_ratings(self.wp10db)
@@ -893,7 +967,7 @@ class CleanupProjectTest(BaseWpOneDbTest):
     self.assertTrue(b'Test main inheritance' not in titles, titles)
     self.assertTrue(b'Failures of tests' not in titles, titles)
     self.assertTrue(b'How to test' not in titles, titles)
-    
+
   def test_updates_quality(self):
     ratings = _get_all_ratings(self.wp10db)
     for article in (b'Testing figures', b'Important tests'):
@@ -908,16 +982,17 @@ class CleanupProjectTest(BaseWpOneDbTest):
         if rating.r_article == article:
           self.assertEqual(self.not_a_class_db, rating.r_importance)
 
+
 class UpdateProjectRecordTest(BaseWpOneDbTest):
   ratings = (
-    (b'Art of testing', b'FA-Class', b'High-Class'),
-    (b'Testing mechanics', b'FA-Class', b'Mid-Class'),
-    (b'Rules of testing',  b'FA-Class', b'NotA-Class'),
-    (b'Test frameworks', b'NotA-Class', b'Mid-Class'),
-    (b'Test practices', b'FL-Class', b'Unassessed-Class'),
-    (b'Testing history', b'FL-Class', b'Unknown-Class'),
-    (b'Testing figures', b'NotA-Class', b'Low-Class'),
-    (b'Important tests', b'Unassessed-Class', b'Low-Class'),
+      (b'Art of testing', b'FA-Class', b'High-Class'),
+      (b'Testing mechanics', b'FA-Class', b'Mid-Class'),
+      (b'Rules of testing', b'FA-Class', b'NotA-Class'),
+      (b'Test frameworks', b'NotA-Class', b'Mid-Class'),
+      (b'Test practices', b'FL-Class', b'Unassessed-Class'),
+      (b'Testing history', b'FL-Class', b'Unknown-Class'),
+      (b'Testing figures', b'NotA-Class', b'Low-Class'),
+      (b'Important tests', b'Unassessed-Class', b'Low-Class'),
   )
 
   def setUp(self):
@@ -928,25 +1003,29 @@ class UpdateProjectRecordTest(BaseWpOneDbTest):
     imp_ts = b'2018-05-01T13:45:10Z'
     with self.wp10db.cursor() as cursor:
       for r in self.ratings:
-        rating = Rating(r_project=self.project.p_project, r_namespace=0,
-                        r_article=r[0], r_quality=r[1], r_importance=r[2],
+        rating = Rating(r_project=self.project.p_project,
+                        r_namespace=0,
+                        r_article=r[0],
+                        r_quality=r[1],
+                        r_importance=r[2],
                         r_quality_timestamp=qual_ts,
                         r_importance_timestamp=imp_ts)
-        cursor.execute('INSERT INTO ' + Rating.table_name + '''
+        cursor.execute(
+            'INSERT INTO ' + Rating.table_name + '''
           (r_project, r_namespace, r_article, r_score, r_quality,
            r_quality_timestamp, r_importance, r_importance_timestamp)
           VALUES (%(r_project)s, %(r_namespace)s, %(r_article)s, %(r_score)s,
                   %(r_quality)s, %(r_quality_timestamp)s, %(r_importance)s,
                   %(r_importance_timestamp)s)
-        ''', attr.asdict(rating))  
+        ''', attr.asdict(rating))
 
     self.metadata = {
-      'homepage': '/homepage',
-      'shortname': 'Test',
-      'parent': 'Nothing',
+        'homepage': '/homepage',
+        'shortname': 'Test',
+        'parent': 'Nothing',
     }
-    logic_project.update_project_record(
-      self.wp10db, self.project, self.metadata)
+    logic_project.update_project_record(self.wp10db, self.project,
+                                        self.metadata)
 
   def test_metadata_correct(self):
     self.assertEqual(self.metadata['homepage'],
@@ -967,20 +1046,31 @@ class UpdateProjectRecordTest(BaseWpOneDbTest):
 
 
 class ProjectNamesTest(ArticlesTest):
+
   def _insert_categories(self):
     ts = datetime(2018, 12, 25, 11, 22, 33)
     root = ROOT_CATEGORY.encode('utf-8')
     pages = [(i, 'Test_%s_articles_by_quality' % i, root) for i in range(30)]
     with self.wikidb.cursor() as cursor:
       for p in pages:
-        cursor.execute('''
+        cursor.execute(
+            '''
           INSERT INTO page (page_id, page_namespace, page_title)
           VALUES (%(id)s, %(ns)s, %(title)s)
-        ''', {'id': p[0], 'ns': CATEGORY_NS_INT, 'title': p[1]})
-        cursor.execute('''
+        ''', {
+                'id': p[0],
+                'ns': CATEGORY_NS_INT,
+                'title': p[1]
+            })
+        cursor.execute(
+            '''
           INSERT INTO categorylinks (cl_from, cl_to, cl_timestamp)
           VALUES (%(from)s, %(to)s, %(ts)s)
-        ''', {'from': p[0], 'to': p[2], 'ts': ts})
+        ''', {
+                'from': p[0],
+                'to': p[2],
+                'ts': ts
+            })
     self.wikidb.commit()
 
   def setUp(self):
@@ -993,9 +1083,11 @@ class ProjectNamesTest(ArticlesTest):
 
 
 class GlobalCountTest(BaseWpOneDbTest):
+
   def _insert_projects(self):
     with self.wp10db.cursor() as cursor:
-      cursor.executemany('''
+      cursor.executemany(
+          '''
         INSERT INTO projects (p_project, p_timestamp)
           VALUES (%s, '20181225001122')
       ''', [('Test Project %s' % i,) for i in range(50)])
@@ -1012,8 +1104,7 @@ class GlobalCountTest(BaseWpOneDbTest):
       self.wp10db.close = lambda: True
       patched_connect.return_value = self.wp10db
       logic_project.update_global_project_count()
-      self.assertEqual(
-        ('50\n', 'Updating count: 50 projects'),
-        patched_api.save_page.call_args_list[0][0][1:])
+      self.assertEqual(('50\n', 'Updating count: 50 projects'),
+                       patched_api.save_page.call_args_list[0][0][1:])
     finally:
       self.wp10db.close = orig_close

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -14,9 +14,11 @@ UNASSESSED_CLASS = config['UNASSESSED_CLASS']
 
 logger = logging.getLogger(__name__)
 
+
 def get_project_ratings(wp10db, project_name):
   with wp10db.cursor() as cursor:
-    cursor.execute('SELECT * FROM ' + Rating.table_name + '''
+    cursor.execute(
+        'SELECT * FROM ' + Rating.table_name + '''
       WHERE r_project = %(r_project)s
     ''', {'r_project': project_name})
     return [Rating(**db_rating) for db_rating in cursor.fetchall()]
@@ -42,11 +44,11 @@ def insert_or_update(wp10db, rating, kind):
                               r_importance_timestamp=%(r_importance_timestamp)s
     '''
   else:
-    raise ValueError('AssessmentKind was not QUALITY or IMPORTANCE: %s',
-                     kind)
+    raise ValueError('AssessmentKind was not QUALITY or IMPORTANCE: %s', kind)
 
   with wp10db.cursor() as cursor:
-    cursor.execute('INSERT INTO ' + Rating.table_name + '''
+    cursor.execute(
+        'INSERT INTO ' + Rating.table_name + '''
       (r_project, r_namespace, r_article, r_score, r_quality,
        r_quality_timestamp, r_importance, r_importance_timestamp)
     VALUES
@@ -59,35 +61,47 @@ def insert_or_update(wp10db, rating, kind):
 def delete_empty_for_project(wp10db, project):
   not_a_class_db = NOT_A_CLASS.encode('utf-8')
   with wp10db.cursor() as cursor:
-    cursor.execute('DELETE FROM ' + Rating.table_name + '''
+    cursor.execute(
+        'DELETE FROM ' + Rating.table_name + '''
       WHERE r_project=%(r_project)s
         AND (r_quality IS NULL OR r_quality=%(not_a_class)s)
         AND (r_importance IS NULL OR r_importance=%(not_a_class)s)
-    ''', {'r_project': project.p_project, 'not_a_class': not_a_class_db})
+    ''', {
+            'r_project': project.p_project,
+            'not_a_class': not_a_class_db
+        })
     return cursor.rowcount
 
 
 def update_null_quality_for_project(wp10db, project):
   not_a_class_db = NOT_A_CLASS.encode('utf-8')
   with wp10db.cursor() as cursor:
-    cursor.execute('UPDATE ' + Rating.table_name + '''
+    cursor.execute(
+        'UPDATE ' + Rating.table_name + '''
       SET r_quality = %(not_a_class)s,
           r_quality_timestamp=r_importance_timestamp
       WHERE r_project=%(r_project)s
         AND r_quality IS NULL
-    ''', {'r_project': project.p_project, 'not_a_class': not_a_class_db})
+    ''', {
+            'r_project': project.p_project,
+            'not_a_class': not_a_class_db
+        })
     return cursor.rowcount
 
 
 def update_null_importance_for_project(wp10db, project):
   not_a_class_db = NOT_A_CLASS.encode('utf-8')
   with wp10db.cursor() as cursor:
-    cursor.execute('UPDATE ' + Rating.table_name + '''
+    cursor.execute(
+        'UPDATE ' + Rating.table_name + '''
       SET r_importance = %(not_a_class)s,
           r_importance_timestamp=r_quality_timestamp
       WHERE r_project=%(r_project)s
         AND r_importance IS NULL
-    ''', {'r_project': project.p_project, 'not_a_class': not_a_class_db})
+    ''', {
+            'r_project': project.p_project,
+            'not_a_class': not_a_class_db
+        })
     return cursor.rowcount
 
 
@@ -95,7 +109,8 @@ def count_for_project(wp10db, project):
   # wp10_session.query(Rating).filter(
   #   Rating.project == project.project).count()
   with wp10db.cursor() as cursor:
-    cursor.execute('SELECT COUNT(*) as cnt FROM ' + Rating.table_name + '''
+    cursor.execute(
+        'SELECT COUNT(*) as cnt FROM ' + Rating.table_name + '''
       WHERE r_project=%(r_project)s
     ''', {'r_project': project.p_project})
     return cursor.fetchone()['cnt']
@@ -105,14 +120,15 @@ def count_unassessed_quality_for_project(wp10db, project):
   not_a_class_db = NOT_A_CLASS.encode('utf-8')
   unassessed_db = UNASSESSED_CLASS.encode('utf-8')
   with wp10db.cursor() as cursor:
-    cursor.execute('SELECT COUNT(*) as cnt FROM ' + Rating.table_name + '''
+    cursor.execute(
+        'SELECT COUNT(*) as cnt FROM ' + Rating.table_name + '''
       WHERE (r_quality = %(not_a_class)s OR r_quality = %(unassessed)s)
         AND r_project = %(r_project)s
     ''', {
-      'r_project': project.p_project,
-      'not_a_class': not_a_class_db,
-      'unassessed': unassessed_db
-    })
+            'r_project': project.p_project,
+            'not_a_class': not_a_class_db,
+            'unassessed': unassessed_db
+        })
     return cursor.fetchone()['cnt']
 
 
@@ -120,14 +136,15 @@ def count_unassessed_importance_for_project(wp10db, project):
   not_a_class_db = NOT_A_CLASS.encode('utf-8')
   unassessed_db = UNASSESSED_CLASS.encode('utf-8')
   with wp10db.cursor() as cursor:
-    cursor.execute('SELECT COUNT(*) as cnt FROM ' + Rating.table_name + '''
+    cursor.execute(
+        'SELECT COUNT(*) as cnt FROM ' + Rating.table_name + '''
       WHERE (r_importance = %(not_a_class)s OR r_importance = %(unassessed)s)
         AND r_project = %(r_project)s
     ''', {
-      'r_project': project.p_project,
-      'not_a_class': not_a_class_db,
-      'unassessed': unassessed_db
-    })
+            'r_project': project.p_project,
+            'not_a_class': not_a_class_db,
+            'unassessed': unassessed_db
+        })
     return cursor.fetchone()['cnt']
 
 
@@ -143,9 +160,12 @@ def add_log_for_rating(wp10db, new_rating, kind, old_rating_value):
   else:
     raise ValueError('Unrecognized value for kind: %s', kind)
 
-  log = Log(
-    l_project=new_rating.r_project, l_namespace=new_rating.r_namespace,
-    l_article=new_rating.r_article, l_timestamp=GLOBAL_TIMESTAMP,
-    l_action=action, l_old=old_rating_value, l_new=new,
-    l_revision_timestamp=timestamp)
+  log = Log(l_project=new_rating.r_project,
+            l_namespace=new_rating.r_namespace,
+            l_article=new_rating.r_article,
+            l_timestamp=GLOBAL_TIMESTAMP,
+            l_action=action,
+            l_old=old_rating_value,
+            l_new=new,
+            l_revision_timestamp=timestamp)
   logic_log.insert_or_update(wp10db, log)

--- a/wp1/logic/rating_test.py
+++ b/wp1/logic/rating_test.py
@@ -6,15 +6,19 @@ from wp1.models.wp10.rating import Rating
 
 
 class LogicRatingTest(BaseWpOneDbTest):
+
   def test_add_log_for_quality_rating(self):
-    rating = Rating(
-      r_project=b'Test Project', r_namespace=0, r_article=b'Testing Stuff',
-      r_quality=b'GA-Class', r_quality_timestamp=b'2018-04-01T12:30:00Z')
-    logic_rating.add_log_for_rating(
-      self.wp10db, rating, AssessmentKind.QUALITY, b'NotA-Class')
+    rating = Rating(r_project=b'Test Project',
+                    r_namespace=0,
+                    r_article=b'Testing Stuff',
+                    r_quality=b'GA-Class',
+                    r_quality_timestamp=b'2018-04-01T12:30:00Z')
+    logic_rating.add_log_for_rating(self.wp10db, rating, AssessmentKind.QUALITY,
+                                    b'NotA-Class')
 
     with self.wp10db.cursor() as cursor:
-      cursor.execute('''
+      cursor.execute(
+          '''
         SELECT * FROM ''' + Log.table_name + '''
         WHERE l_article = %s
       ''', (b'Testing Stuff',))
@@ -29,15 +33,17 @@ class LogicRatingTest(BaseWpOneDbTest):
     self.assertEqual(b'quality', log.l_action)
 
   def test_add_log_for_importance_rating(self):
-    rating = Rating(
-      r_project=b'Test Project', r_namespace=0, r_article=b'Testing Stuff',
-      r_importance=b'Mid-Class',
-      r_importance_timestamp=b'2018-04-01T12:30:00Z')
-    logic_rating.add_log_for_rating(
-      self.wp10db, rating, AssessmentKind.IMPORTANCE, b'NotA-Class')
+    rating = Rating(r_project=b'Test Project',
+                    r_namespace=0,
+                    r_article=b'Testing Stuff',
+                    r_importance=b'Mid-Class',
+                    r_importance_timestamp=b'2018-04-01T12:30:00Z')
+    logic_rating.add_log_for_rating(self.wp10db, rating,
+                                    AssessmentKind.IMPORTANCE, b'NotA-Class')
 
     with self.wp10db.cursor() as cursor:
-      cursor.execute('''
+      cursor.execute(
+          '''
         SELECT * FROM ''' + Log.table_name + '''
         WHERE l_article = %s
       ''', (b'Testing Stuff',))

--- a/wp1/logic/review.py
+++ b/wp1/logic/review.py
@@ -5,18 +5,17 @@ from wp1.models.wp10.review import Review
 
 logger = logging.getLogger(__name__)
 
-def insert_or_update_review_data(
-    wp10_session, page_title, value, timestamp):
-  timestamp_binary = time.strftime(
-    '%Y-%m-%dT%H:%M:%SZ', timestamp.timetuple()).encode('utf-8')
+
+def insert_or_update_review_data(wp10_session, page_title, value, timestamp):
+  timestamp_binary = time.strftime('%Y-%m-%dT%H:%M:%SZ',
+                                   timestamp.timetuple()).encode('utf-8')
   if value not in (b'GA', b'FA', b'FL'):
     raise ValueError('Unrecognized review value: %s' % value)
 
   review = wp10_session.query(Review).get(page_title)
   if review is None:
     logging.info('New article found: %s', page_title.decode('utf-8'))
-    review = Review(
-      article=page_title, value=value, timestamp=timestamp_binary)
+    review = Review(article=page_title, value=value, timestamp=timestamp_binary)
   else:
     logging.info('Updating article: %s', page_title.decode('utf-8'))
     review.article = page_title

--- a/wp1/logic/util.py
+++ b/wp1/logic/util.py
@@ -10,8 +10,11 @@ BY_IMPORTANCE_ALT_STR = config['BY_IMPORTANCE_ALT']
 ARTICLES_LABEL_STR = config['ARTICLES_LABEL']
 DATABASE_WIKI_TS = config['DATABASE_WIKI_TS']
 
-def category_for_project_by_kind(
-    project_name, kind, category_prefix=True, use_alt=False):
+
+def category_for_project_by_kind(project_name,
+                                 kind,
+                                 category_prefix=True,
+                                 use_alt=False):
   if kind == AssessmentKind.QUALITY:
     kind_tag = BY_QUALITY_STR
   elif kind == AssessmentKind.IMPORTANCE:
@@ -27,26 +30,30 @@ def category_for_project_by_kind(
     return_bytes = True
     project_name = project_name.decode('utf-8')
 
-  category = '%s_%s_%s' % (
-    project_name, ARTICLES_LABEL_STR, kind_tag)
+  category = '%s_%s_%s' % (project_name, ARTICLES_LABEL_STR, kind_tag)
 
   if category_prefix:
     category = CATEGORY_NS_STR + ':' + category
 
   return category.encode('utf-8') if return_bytes else category
 
+
 def is_namespace_acceptable(ns):
   if ns < 0 or ns == 2 or ns % 2 == 1:
     return False
   return True
+
 
 def title_for_api(wp10db, namespace, title):
   title = title.decode('utf-8')
   ns_str = int_to_ns(wp10db)[namespace].decode('utf-8')
   return '%s:%s' % (ns_str, title)
 
+
 _NS_TO_INT = None
 _INT_TO_NS = None
+
+
 def ns_to_int(wp10db):
   global _NS_TO_INT
   if _NS_TO_INT is not None:
@@ -55,13 +62,15 @@ def ns_to_int(wp10db):
     if _INT_TO_NS is not None:
       _NS_TO_INT = {v: k for k, v in _INT_TO_NS.items()}
       return _NS_TO_INT
-     
+
     with wp10db.cursor() as cursor:
-      cursor.execute('SELECT * FROM ' + Namespace.table_name + '''
+      cursor.execute(
+          'SELECT * FROM ' + Namespace.table_name + '''
         WHERE dbname=%(dbname)s
       ''', {'dbname': DATABASE_WIKI_TS.encode('utf-8')})
       _NS_TO_INT = dict((n['ns_name'], n['ns_id']) for n in cursor.fetchall())
     return _NS_TO_INT
+
 
 def int_to_ns(wp10db):
   global _INT_TO_NS

--- a/wp1/models/wiki/log.py
+++ b/wp1/models/wiki/log.py
@@ -5,6 +5,7 @@ from sqlalchemy.dialects.mysql import BIGINT, BINARY, BLOB, INTEGER
 
 from wp1.wiki_db import Base
 
+
 class Log(Base):
   __tablename__ = 'logging'
 
@@ -17,9 +18,9 @@ class Log(Base):
 
   def __repr__(self):
     return "<Log(namespace=%r, title=%r, timestamp=%r, type=%r)>" % (
-      self.namespace, self.title, self.timestamp, self.type)
+        self.namespace, self.title, self.timestamp, self.type)
 
   @property
   def timestamp_dt(self):
-    return datetime.strptime(
-      self.quality_timestamp.decode('utf-8'), '%Y%m%dT%H%M%S')
+    return datetime.strptime(self.quality_timestamp.decode('utf-8'),
+                             '%Y%m%dT%H%M%S')

--- a/wp1/models/wiki/page.py
+++ b/wp1/models/wiki/page.py
@@ -6,6 +6,7 @@ config = get_conf()
 ARTICLES_LABEL_STR = config['ARTICLES_LABEL']
 BY_QUALITY_STR = config['BY_QUALITY']
 
+
 @attr.s
 class Page:
   """An approximation of a wikipedia page, for use in this bot.

--- a/wp1/models/wp10/category.py
+++ b/wp1/models/wp10/category.py
@@ -1,5 +1,6 @@
 import attr
 
+
 @attr.s
 class Category:
   table_name = 'categories'

--- a/wp1/models/wp10/log.py
+++ b/wp1/models/wp10/log.py
@@ -4,6 +4,7 @@ import attr
 
 from wp1.constants import TS_FORMAT_WP10
 
+
 @attr.s
 class Log:
   table_name = 'logging'

--- a/wp1/models/wp10/log_test.py
+++ b/wp1/models/wp10/log_test.py
@@ -2,7 +2,9 @@ from wp1.base_db_test import BaseWpOneDbTest
 from wp1.logic import log as logic_log
 from wp1.models.wp10.log import Log
 
+
 class ModelsLogTest(BaseWpOneDbTest):
+
   def setUp(self):
     super().setUp()
     self.project_name = b'My test project'
@@ -10,10 +12,14 @@ class ModelsLogTest(BaseWpOneDbTest):
     self.article = b'The Art of Testing (book)'
     self.action = b'quality'
     self.timestamp = b'20180401123000'
-    self.log = Log(
-      l_project=self.project_name, l_namespace=self.ns, l_article=self.article,
-      l_action=self.action, l_timestamp=self.timestamp, l_old=b'NotA-Class',
-      l_new=b'Mid-Class', l_revision_timestamp=b'2018-01-01T12:00:00Z')
+    self.log = Log(l_project=self.project_name,
+                   l_namespace=self.ns,
+                   l_article=self.article,
+                   l_action=self.action,
+                   l_timestamp=self.timestamp,
+                   l_old=b'NotA-Class',
+                   l_new=b'Mid-Class',
+                   l_revision_timestamp=b'2018-01-01T12:00:00Z')
     logic_log.insert_or_update(self.wp10db, self.log)
 
   def test_timestamp_dt(self):

--- a/wp1/models/wp10/move.py
+++ b/wp1/models/wp10/move.py
@@ -4,6 +4,7 @@ import attr
 
 from wp1.constants import TS_FORMAT
 
+
 @attr.s
 class Move:
   table_name = 'moves'

--- a/wp1/models/wp10/namespace.py
+++ b/wp1/models/wp10/namespace.py
@@ -2,10 +2,12 @@ import enum
 
 import attr
 
+
 class NsType(enum.Enum):
   primary = 0
   canonical = 1
   alias = 2
+
 
 @attr.s
 class Namespace:

--- a/wp1/models/wp10/project.py
+++ b/wp1/models/wp10/project.py
@@ -4,6 +4,7 @@ import attr
 
 from wp1.constants import TS_FORMAT_WP10
 
+
 @attr.s
 class Project:
   table_name = 'projects'

--- a/wp1/models/wp10/project_test.py
+++ b/wp1/models/wp10/project_test.py
@@ -2,13 +2,16 @@ from wp1.base_db_test import BaseWpOneDbTest
 from wp1.logic import project as logic_project
 from wp1.models.wp10.project import Project
 
+
 class ModelsProjectTest(BaseWpOneDbTest):
+
   def setUp(self):
     super().setUp()
     self.project_name = b'My test project'
-    self.project = Project(
-      p_project=self.project_name, p_timestamp=b'20180930123000', p_count=100,
-      p_upload_timestamp=b'20180929120000')
+    self.project = Project(p_project=self.project_name,
+                           p_timestamp=b'20180930123000',
+                           p_count=100,
+                           p_upload_timestamp=b'20180929120000')
     logic_project.insert_or_update(self.wp10db, self.project)
 
   def test_timestamp_dt(self):

--- a/wp1/models/wp10/rating.py
+++ b/wp1/models/wp10/rating.py
@@ -7,6 +7,7 @@ from wp1.constants import TS_FORMAT
 
 logger = logging.getLogger(__name__)
 
+
 @attr.s
 class Rating:
   table_name = 'ratings'
@@ -23,13 +24,13 @@ class Rating:
   # The timestamp parsed into a datetime.datetime object.
   @property
   def quality_timestamp_dt(self):
-    return datetime.strptime(
-      self.r_quality_timestamp.decode('utf-8'), TS_FORMAT)
+    return datetime.strptime(self.r_quality_timestamp.decode('utf-8'),
+                             TS_FORMAT)
 
   @property
   def importance_timestamp_dt(self):
-    return datetime.strptime(
-      self.r_importance_timestamp.decode('utf-8'), TS_FORMAT)
+    return datetime.strptime(self.r_importance_timestamp.decode('utf-8'),
+                             TS_FORMAT)
 
   def set_quality_timestamp_dt(self, dt):
     """Sets the quality_timestamp field using a datetime.datetime object"""
@@ -42,6 +43,6 @@ class Rating:
     """Sets the quality_timestamp field using a datetime.datetime object"""
     if dt is None:
       logger.warning(
-        'Attempt to set rating importance_timestamp to None ignored')
+          'Attempt to set rating importance_timestamp to None ignored')
       return
     self.r_importance_timestamp = dt.strftime(TS_FORMAT).encode('utf-8')

--- a/wp1/models/wp10/release.py
+++ b/wp1/models/wp10/release.py
@@ -1,5 +1,6 @@
 import attr
 
+
 @attr.s
 class Release:
   table_name = 'releases'

--- a/wp1/models/wp10/review.py
+++ b/wp1/models/wp10/review.py
@@ -3,6 +3,7 @@ from sqlalchemy.dialects.mysql import BINARY
 
 from wp1.wp10_db import Base
 
+
 class Review(Base):
   __tablename__ = 'reviews'
 
@@ -12,4 +13,4 @@ class Review(Base):
 
   def __repr__(self):
     return "<Review(value=%r, article=%r, timestamp=%r)>" % (
-      self.value, self.article, self.timestamp)
+        self.value, self.article, self.timestamp)

--- a/wp1/tables.py
+++ b/wp1/tables.py
@@ -10,21 +10,22 @@ from wp1.models.wp10.category import Category
 from wp1.models.wp10.rating import Rating
 from wp1.wp10_db import connect as wp10_connect
 
+
 def commas(n):
   return "{:,d}".format(n)
 
+
 logger = logging.getLogger(__name__)
 
-jinja_env = Environment(
-    loader=PackageLoader('wp1', 'templates'),
-    autoescape=select_autoescape(['html', 'xml'])
-)
+jinja_env = Environment(loader=PackageLoader('wp1', 'templates'),
+                        autoescape=select_autoescape(['html', 'xml']))
 jinja_env.filters['commas'] = commas
 
 config = get_conf()
 NOT_A_CLASS = config['NOT_A_CLASS'].encode('utf-8')
 ASSESSED_CLASS = b'Assessed-Class'
 UNASSESSED_CLASS = b'Unassessed-Class'
+
 
 def labels_for_classes(sort_qual, sort_imp):
   qual_labels = {}
@@ -44,38 +45,38 @@ def labels_for_classes(sort_qual, sort_imp):
 
 def get_global_categories():
   sort_qual = {
-    b'FA-Class':     500,
-    b'FL-Class':     480,
-    b'A-Class':      425, 
-    b'GA-Class':     400,
-    b'B-Class':      300,
-    b'C-Class':      225, 
-    b'Start-Class':  150,
-    b'Stub-Class':   100,
-    b'List-Class':    80, 
-    ASSESSED_CLASS:   20,
-    NOT_A_CLASS:      11,
-    b'Unknown-Class': 10,
-    UNASSESSED_CLASS:  0,
+      b'FA-Class': 500,
+      b'FL-Class': 480,
+      b'A-Class': 425,
+      b'GA-Class': 400,
+      b'B-Class': 300,
+      b'C-Class': 225,
+      b'Start-Class': 150,
+      b'Stub-Class': 100,
+      b'List-Class': 80,
+      ASSESSED_CLASS: 20,
+      NOT_A_CLASS: 11,
+      b'Unknown-Class': 10,
+      UNASSESSED_CLASS: 0,
   }
 
-  sort_imp= {
-    b'Top-Class':    400,
-    b'High-Class':   300, 
-    b'Mid-Class':    200,
-    b'Low-Class':    100, 
-    NOT_A_CLASS:      11,
-    b'Unknown-Class': 10,
-    UNASSESSED_CLASS:  0,
+  sort_imp = {
+      b'Top-Class': 400,
+      b'High-Class': 300,
+      b'Mid-Class': 200,
+      b'Low-Class': 100,
+      NOT_A_CLASS: 11,
+      b'Unknown-Class': 10,
+      UNASSESSED_CLASS: 0,
   }
-  
+
   qual_labels, imp_labels = labels_for_classes(sort_qual, sort_imp)
 
   return {
-    'sort_qual': sort_qual,
-    'sort_imp': sort_imp,
-    'qual_labels': qual_labels,
-    'imp_labels': imp_labels,
+      'sort_qual': sort_qual,
+      'sort_imp': sort_imp,
+      'qual_labels': qual_labels,
+      'imp_labels': imp_labels,
   }
 
 
@@ -96,7 +97,8 @@ def get_global_stats(wp10db):
 
 def get_project_stats(wp10db, project_name):
   with wp10db.cursor() as cursor:
-    cursor.execute('''
+    cursor.execute(
+        '''
       SELECT count(r_article) as n, r_quality as q, r_importance as i,
              r_project as project
       FROM ''' + Rating.table_name + '''
@@ -107,8 +109,9 @@ def get_project_stats(wp10db, project_name):
 
 def db_project_categories(wp10db, project_name):
   with wp10db.cursor() as cursor:
-    cursor.execute('SELECT c_type, c_rating, c_ranking, c_category FROM ' +
-                   Category.table_name + ' WHERE c_project = %s', (project_name,))
+    cursor.execute(
+        'SELECT c_type, c_rating, c_ranking, c_category FROM ' +
+        Category.table_name + ' WHERE c_project = %s', (project_name,))
 
     return cursor.fetchall()
 
@@ -139,17 +142,16 @@ def get_project_categories(wp10db, project_name):
         labels = qual_labels
       elif row['c_type'] == b'importance':
         labels = imp_labels
-        
+
       labels[row['c_rating']] = (
-        '{{%s|category=Category:%s}}' % (row['c_rating'].decode('utf-8'),
-                                         row['c_category'].decode('utf-8'))
-      )
-                       
+          '{{%s|category=Category:%s}}' %
+          (row['c_rating'].decode('utf-8'), row['c_category'].decode('utf-8')))
+
   return {
-    'sort_qual': sort_qual,
-    'sort_imp': sort_imp,
-    'qual_labels': qual_labels,
-    'imp_labels': imp_labels,
+      'sort_qual': sort_qual,
+      'sort_imp': sort_imp,
+      'qual_labels': qual_labels,
+      'imp_labels': imp_labels,
   }
 
 
@@ -191,9 +193,11 @@ def generate_table_data(stats, categories, table_overrides=None):
     del data[r]
 
   # Step 3 - Sort the rows and columns by their ranking value
-  ordered_cols = sorted(cols.keys(), key=lambda x: categories['sort_imp'][x],
+  ordered_cols = sorted(cols.keys(),
+                        key=lambda x: categories['sort_imp'][x],
                         reverse=True)
-  ordered_rows = sorted(data.keys(), key=lambda x: categories['sort_qual'][x],
+  ordered_rows = sorted(data.keys(),
+                        key=lambda x: categories['sort_qual'][x],
                         reverse=True)
   if UNASSESSED_CLASS in ordered_rows:
     idx = ordered_rows.index(UNASSESSED_CLASS)
@@ -220,15 +224,15 @@ def generate_table_data(stats, categories, table_overrides=None):
     row_totals[b'Assessed-Class'] += d
 
   ans = {
-    **table_overrides,
-    'data':  data,
-    'ordered_cols': ordered_cols,
-    'ordered_rows': ordered_rows,
-    'row_totals': row_totals,
-    'col_totals': col_totals,
-    'total': total,
-    'col_labels': categories['imp_labels'],
-    'row_labels': categories['qual_labels'],
+      **table_overrides,
+      'data': data,
+      'ordered_cols': ordered_cols,
+      'ordered_rows': ordered_rows,
+      'row_totals': row_totals,
+      'col_totals': col_totals,
+      'total': total,
+      'col_labels': categories['imp_labels'],
+      'row_labels': categories['qual_labels'],
   }
 
   # If we have only one column, don't display it because it is identical to the
@@ -242,31 +246,35 @@ def generate_table_data(stats, categories, table_overrides=None):
 
 
 def generate_project_table_data(wp10db, project_name):
-    stats = get_project_stats(wp10db, project_name)
-    categories = get_project_categories(wp10db, project_name)
-    project_display = project_name.decode('utf-8').replace('_', ' ')
-    title = ('%s articles by quality and importance' % project_display)
+  stats = get_project_stats(wp10db, project_name)
+  categories = get_project_categories(wp10db, project_name)
+  project_display = project_name.decode('utf-8').replace('_', ' ')
+  title = ('%s articles by quality and importance' % project_display)
 
-    return generate_table_data(stats, categories, {
-      'project': project_name,
-      'project_display': project_display,
-      'create_link': True,
-      'title': title,
-      'center_table': False,
-    })
+  return generate_table_data(
+      stats, categories, {
+          'project': project_name,
+          'project_display': project_display,
+          'create_link': True,
+          'title': title,
+          'center_table': False,
+      })
 
 
 def generate_global_table_data(wp10db):
   stats = get_global_stats(wp10db)
   categories = get_global_categories()
 
-  return generate_table_data(stats, categories, {
-    'project': None,
-    'project_display': 'All articles',
-    'create_link': False, # Whether the values link to the web app.
-    'title': 'All rated articles by quality and importance',
-    'center_table': True,
-  })
+  return generate_table_data(
+      stats,
+      categories,
+      {
+          'project': None,
+          'project_display': 'All articles',
+          'create_link': False,  # Whether the values link to the web app.
+          'title': 'All rated articles by quality and importance',
+          'center_table': True,
+      })
 
 
 def upload_project_table(project_name):
@@ -305,11 +313,12 @@ def upload_global_table():
     if wp10db is not None:
       wp10db.close()
 
+
 def create_wikicode(table_data):
   template = jinja_env.get_template('table.jinja2')
   display = {
-    'LIST_URL': LIST_URL,
-    # Number of columns plus one, plus a column for Total.
-    'total_cols': len(table_data['ordered_cols']) + 2,
+      'LIST_URL': LIST_URL,
+      # Number of columns plus one, plus a column for Total.
+      'total_cols': len(table_data['ordered_cols']) + 2,
   }
   return template.render({**table_data, **display})

--- a/wp1/tables_test.py
+++ b/wp1/tables_test.py
@@ -9,31 +9,32 @@ from wp1.constants import AssessmentKind, CATEGORY_NS_INT, GLOBAL_TIMESTAMP_WIKI
 from wp1.models.wp10.category import Category
 from wp1.models.wp10.rating import Rating
 
+
 class TablesCategoryTest(unittest.TestCase):
   GLOBAL_SORT_QUAL = {
-    b'FA-Class':     500,
-    b'FL-Class':     480,
-    b'A-Class':      425, 
-    b'GA-Class':     400,
-    b'B-Class':      300,
-    b'C-Class':      225, 
-    b'Start-Class':  150,
-    b'Stub-Class':   100,
-    b'List-Class':    80, 
-    tables.ASSESSED_CLASS:   20,
-    tables.NOT_A_CLASS:      11,
-    b'Unknown-Class': 10,
-    tables.UNASSESSED_CLASS:  0,
+      b'FA-Class': 500,
+      b'FL-Class': 480,
+      b'A-Class': 425,
+      b'GA-Class': 400,
+      b'B-Class': 300,
+      b'C-Class': 225,
+      b'Start-Class': 150,
+      b'Stub-Class': 100,
+      b'List-Class': 80,
+      tables.ASSESSED_CLASS: 20,
+      tables.NOT_A_CLASS: 11,
+      b'Unknown-Class': 10,
+      tables.UNASSESSED_CLASS: 0,
   }
 
   GLOBAL_SORT_IMP = {
-    b'Top-Class':    400,
-    b'High-Class':   300, 
-    b'Mid-Class':    200,
-    b'Low-Class':    100, 
-    tables.NOT_A_CLASS:      11,
-    b'Unknown-Class': 10,
-    tables.UNASSESSED_CLASS:  0,
+      b'Top-Class': 400,
+      b'High-Class': 300,
+      b'Mid-Class': 200,
+      b'Low-Class': 100,
+      tables.NOT_A_CLASS: 11,
+      b'Unknown-Class': 10,
+      tables.UNASSESSED_CLASS: 0,
   }
 
   def test_commas(self):
@@ -45,8 +46,8 @@ class TablesCategoryTest(unittest.TestCase):
     self.assertEqual('123', actual)
 
   def test_labels_for_classes(self):
-    actual_qual, actual_imp = tables.labels_for_classes(
-      self.GLOBAL_SORT_QUAL, self.GLOBAL_SORT_IMP)
+    actual_qual, actual_imp = tables.labels_for_classes(self.GLOBAL_SORT_QUAL,
+                                                        self.GLOBAL_SORT_IMP)
 
     self.assertEqual(len(self.GLOBAL_SORT_QUAL), len(actual_qual))
     self.assertEqual(len(self.GLOBAL_SORT_IMP), len(actual_imp))
@@ -79,229 +80,312 @@ class TablesCategoryTest(unittest.TestCase):
     self.assertEqual(self.GLOBAL_SORT_IMP, actual['sort_imp'])
     self.assertEqual(self.GLOBAL_SORT_QUAL, actual['sort_qual'])
 
+
 class TablesDbTest(BaseWpOneDbTest):
   global_articles = [
-    (225, 100, 475),
-    (150, 0, 625),
-    (100, 100, 229),
-    (150, 100, 589),
-    (150, 200, 596),
-    (150, 100, 398),
-    (0, 0, 109),
-    (225, 100, 434),
-    (150, 300, 629),
-    (150, 300, 629),
-    (150, 300, 629),
-    (100, 100, 461),
-    (225, 0, 288),
-    (0, 0, 35),
-    (150, 100, 665),
-    (150, 100, 527),
-    (100,0, 176),
-    (150, 100, 37),
-    (15, 100, 279),
-    (150, 100, 279),
-    (100, 100, 415),
+      (225, 100, 475),
+      (150, 0, 625),
+      (100, 100, 229),
+      (150, 100, 589),
+      (150, 200, 596),
+      (150, 100, 398),
+      (0, 0, 109),
+      (225, 100, 434),
+      (150, 300, 629),
+      (150, 300, 629),
+      (150, 300, 629),
+      (100, 100, 461),
+      (225, 0, 288),
+      (0, 0, 35),
+      (150, 100, 665),
+      (150, 100, 527),
+      (100, 0, 176),
+      (150, 100, 37),
+      (15, 100, 279),
+      (150, 100, 279),
+      (100, 100, 415),
   ]
 
-  ratings = [
-    (b'Art of testing', b'FA-Class', b'Top-Class'),
-    (b'Testing mechanics', b'FA-Class', b'Top-Class'),
-    (b'Rules of testing', b'FA-Class', b'Top-Class'),
-    (b'Test practices', b'FL-Class', b'Top-Class'),
-    (b'Testing history', b'FL-Class', b'High-Class'),
-    (b'Test frameworks', b'FL-Class', b'High-Class'),
-    (b'Testing figures', b'A-Class', b'High-Class'),
-    (b'Important tests', b'A-Class', b'High-Class'),
-    (b'Test results', b'A-Class', b'Mid-Class'),
-    (b'Test main inheritance', b'GA-Class', b'Mid-Class'),
-    (b'Test sub inheritance', b'GA-Class', b'Mid-Class'),
-    (b'Test other inheritance', b'GA-Class', b'Mid-Class'),
-    (b'Testing best practices', b'B-Class', b'Low-Class'),
-    (b'Testing tools', b'B-Class', b'Low-Class'),
-    (b'Operation of tests', b'B-Class', b'Low-Class'),
-    (b'Lesser-known tests', b'C-Class', b'Low-Class'),
-    (b'Failures of tests', b'C-Class', b'Low-Class'),
-    (b'How to test', b'C-Class', b'Low-Class')
-  ]
+  ratings = [(b'Art of testing', b'FA-Class', b'Top-Class'),
+             (b'Testing mechanics', b'FA-Class', b'Top-Class'),
+             (b'Rules of testing', b'FA-Class', b'Top-Class'),
+             (b'Test practices', b'FL-Class', b'Top-Class'),
+             (b'Testing history', b'FL-Class', b'High-Class'),
+             (b'Test frameworks', b'FL-Class', b'High-Class'),
+             (b'Testing figures', b'A-Class', b'High-Class'),
+             (b'Important tests', b'A-Class', b'High-Class'),
+             (b'Test results', b'A-Class', b'Mid-Class'),
+             (b'Test main inheritance', b'GA-Class', b'Mid-Class'),
+             (b'Test sub inheritance', b'GA-Class', b'Mid-Class'),
+             (b'Test other inheritance', b'GA-Class', b'Mid-Class'),
+             (b'Testing best practices', b'B-Class', b'Low-Class'),
+             (b'Testing tools', b'B-Class', b'Low-Class'),
+             (b'Operation of tests', b'B-Class', b'Low-Class'),
+             (b'Lesser-known tests', b'C-Class', b'Low-Class'),
+             (b'Failures of tests', b'C-Class', b'Low-Class'),
+             (b'How to test', b'C-Class', b'Low-Class')]
 
   project_categories = [
-      {'c_category': b'High-importance_Catholicism_articles',
-       'c_ranking': 300,
-       'c_rating': b'High-Class',
-       'c_type': b'importance'},
-       {'c_category': b'Low-importance_Catholicism_articles',
-        'c_ranking': 100,
-        'c_rating': b'Low-Class',
-        'c_type': b'importance'},
-       {'c_category': b'Mid-importance_Catholicism_articles',
-        'c_ranking': 200,
-        'c_rating': b'Mid-Class',
-        'c_type': b'importance'},
-       {'c_category': b'NA-importance_Catholicism_articles',
-        'c_ranking': 25,
-        'c_rating': b'NA-Class',
-        'c_type': b'importance'},
-       {'c_category': b'',
-        'c_ranking': 21,
-        'c_rating': b'NotA-Class',
-        'c_type': b'importance'},
-       {'c_category': b'Top-importance_Catholicism_articles',
-        'c_ranking': 400,
-        'c_rating': b'Top-Class',
-        'c_type': b'importance'},
-       {'c_category': b'Unknown-importance_Catholicism_articles',
-        'c_ranking': 0,
-        'c_rating': b'Unknown-Class',
-        'c_type': b'importance'},
-       {'c_category': b'A-Class_Catholicism_articles',
-        'c_ranking': 425,
-        'c_rating': b'A-Class',
-        'c_type': b'quality'},
-       {'c_category': b'B-Class_Catholicism_articles',
-        'c_ranking': 300,
-        'c_rating': b'B-Class',
-        'c_type': b'quality'},
-       {'c_category': b'Book-Class_Catholicism_articles',
-        'c_ranking': 55,
-        'c_rating': b'Book-Class',
-        'c_type': b'quality'},
-       {'c_category': b'C-Class_Catholicism_articles',
-        'c_ranking': 225,
-        'c_rating': b'C-Class',
-        'c_type': b'quality'},
-       {'c_category': b'Category-Class_Catholicism_articles',
-        'c_ranking': 50,
-        'c_rating': b'Category-Class',
-        'c_type': b'quality'},
-       {'c_category': b'Disambig-Class_Catholicism_articles',
-        'c_ranking': 48,
-        'c_rating': b'Disambig-Class',
-        'c_type': b'quality'},
-       {'c_category': b'FA-Class_Catholicism_articles',
-        'c_ranking': 500,
-        'c_rating': b'FA-Class',
-        'c_type': b'quality'},
-       {'c_category': b'FL-Class_Catholicism_articles',
-        'c_ranking': 480,
-        'c_rating': b'FL-Class',
-        'c_type': b'quality'},
-       {'c_category': b'FM-Class_Catholicism_articles',
-        'c_ranking': 460,
-        'c_rating': b'FM-Class',
-        'c_type': b'quality'},
-       {'c_category': b'File-Class_Catholicism_articles',
-        'c_ranking': 46,
-        'c_rating': b'File-Class',
-        'c_type': b'quality'},
-       {'c_category': b'GA-Class_Catholicism_articles',
-        'c_ranking': 400,
-        'c_rating': b'GA-Class',
-        'c_type': b'quality'},
-       {'c_category': b'Category:Image-Class Catholicism articles',
-        'c_ranking': 47,
-        'c_rating': b'Image-Class',
-        'c_type': b'quality'},
-       {'c_category': b'List-Class_Catholicism_articles',
-        'c_ranking': 80,
-        'c_rating': b'List-Class',
-        'c_type': b'quality'},
-       {'c_category': b'NA-Class_Catholicism_articles',
-        'c_ranking': 25,
-        'c_rating': b'NA-Class',
-        'c_type': b'quality'},
-       {'c_category': b'',
-        'c_ranking': 21,
-        'c_rating': b'NotA-Class',
-        'c_type': b'quality'},
-       {'c_category': b'Portal-Class_Catholicism_articles',
-        'c_ranking': 45,
-        'c_rating': b'Portal-Class',
-        'c_type': b'quality'},
-       {'c_category': b'Project-Class_Catholicism_articles',
-        'c_ranking': 44,
-        'c_rating': b'Project-Class',
-        'c_type': b'quality'},
-       {'c_category': b'Redirect-Class_Catholicism_articles',
-        'c_ranking': 43,
-        'c_rating': b'Redirect-Class',
-        'c_type': b'quality'},
-       {'c_category': b'Start-Class_Catholicism_articles',
-        'c_ranking': 150,
-        'c_rating': b'Start-Class',
-        'c_type': b'quality'},
-       {'c_category': b'Stub-Class_Catholicism_articles',
-        'c_ranking': 100,
-        'c_rating': b'Stub-Class',
-        'c_type': b'quality'},
-       {'c_category': b'Template-Class_Catholicism_articles',
-        'c_ranking': 40,
-        'c_rating': b'Template-Class',
-        'c_type': b'quality'},
-       {'c_category': b'Unassessed_Catholicism_articles',
-        'c_ranking': 0,
-        'c_rating': b'Unassessed-Class',
-        'c_type': b'quality'},
-    ]
-
-  stats = [
-    {'n': 2, 'q': b'C-Class', 'i': b'Low-Class'},
-    {'n': 1, 'q': b'C-Class', 'i': b'Unknown-Class'},
-    {'n': 3, 'q': b'Start-Class', 'i': b'High-Class'},
-    {'n': 6, 'q': b'Start-Class', 'i': b'Low-Class'},
-      {'n': 1, 'q': b'Start-Class', 'i': b'Mid-Class'},
-    {'n': 1, 'q': b'Start-Class', 'i': b'Unknown-Class'},
-    {'n': 3, 'q': b'Stub-Class', 'i': b'Low-Class'},
-    {'n': 1, 'q': b'Stub-Class', 'i': b'Unknown-Class'},
-      {'n': 2, 'q': b'Unassessed-Class', 'i': b'Unknown-Class'}
+      {
+          'c_category': b'High-importance_Catholicism_articles',
+          'c_ranking': 300,
+          'c_rating': b'High-Class',
+          'c_type': b'importance'
+      },
+      {
+          'c_category': b'Low-importance_Catholicism_articles',
+          'c_ranking': 100,
+          'c_rating': b'Low-Class',
+          'c_type': b'importance'
+      },
+      {
+          'c_category': b'Mid-importance_Catholicism_articles',
+          'c_ranking': 200,
+          'c_rating': b'Mid-Class',
+          'c_type': b'importance'
+      },
+      {
+          'c_category': b'NA-importance_Catholicism_articles',
+          'c_ranking': 25,
+          'c_rating': b'NA-Class',
+          'c_type': b'importance'
+      },
+      {
+          'c_category': b'',
+          'c_ranking': 21,
+          'c_rating': b'NotA-Class',
+          'c_type': b'importance'
+      },
+      {
+          'c_category': b'Top-importance_Catholicism_articles',
+          'c_ranking': 400,
+          'c_rating': b'Top-Class',
+          'c_type': b'importance'
+      },
+      {
+          'c_category': b'Unknown-importance_Catholicism_articles',
+          'c_ranking': 0,
+          'c_rating': b'Unknown-Class',
+          'c_type': b'importance'
+      },
+      {
+          'c_category': b'A-Class_Catholicism_articles',
+          'c_ranking': 425,
+          'c_rating': b'A-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'B-Class_Catholicism_articles',
+          'c_ranking': 300,
+          'c_rating': b'B-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'Book-Class_Catholicism_articles',
+          'c_ranking': 55,
+          'c_rating': b'Book-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'C-Class_Catholicism_articles',
+          'c_ranking': 225,
+          'c_rating': b'C-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'Category-Class_Catholicism_articles',
+          'c_ranking': 50,
+          'c_rating': b'Category-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'Disambig-Class_Catholicism_articles',
+          'c_ranking': 48,
+          'c_rating': b'Disambig-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'FA-Class_Catholicism_articles',
+          'c_ranking': 500,
+          'c_rating': b'FA-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'FL-Class_Catholicism_articles',
+          'c_ranking': 480,
+          'c_rating': b'FL-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'FM-Class_Catholicism_articles',
+          'c_ranking': 460,
+          'c_rating': b'FM-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'File-Class_Catholicism_articles',
+          'c_ranking': 46,
+          'c_rating': b'File-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'GA-Class_Catholicism_articles',
+          'c_ranking': 400,
+          'c_rating': b'GA-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'Category:Image-Class Catholicism articles',
+          'c_ranking': 47,
+          'c_rating': b'Image-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'List-Class_Catholicism_articles',
+          'c_ranking': 80,
+          'c_rating': b'List-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'NA-Class_Catholicism_articles',
+          'c_ranking': 25,
+          'c_rating': b'NA-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'',
+          'c_ranking': 21,
+          'c_rating': b'NotA-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'Portal-Class_Catholicism_articles',
+          'c_ranking': 45,
+          'c_rating': b'Portal-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'Project-Class_Catholicism_articles',
+          'c_ranking': 44,
+          'c_rating': b'Project-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'Redirect-Class_Catholicism_articles',
+          'c_ranking': 43,
+          'c_rating': b'Redirect-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'Start-Class_Catholicism_articles',
+          'c_ranking': 150,
+          'c_rating': b'Start-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'Stub-Class_Catholicism_articles',
+          'c_ranking': 100,
+          'c_rating': b'Stub-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'Template-Class_Catholicism_articles',
+          'c_ranking': 40,
+          'c_rating': b'Template-Class',
+          'c_type': b'quality'
+      },
+      {
+          'c_category': b'Unassessed_Catholicism_articles',
+          'c_ranking': 0,
+          'c_rating': b'Unassessed-Class',
+          'c_type': b'quality'
+      },
   ]
 
+  stats = [{
+      'n': 2,
+      'q': b'C-Class',
+      'i': b'Low-Class'
+  }, {
+      'n': 1,
+      'q': b'C-Class',
+      'i': b'Unknown-Class'
+  }, {
+      'n': 3,
+      'q': b'Start-Class',
+      'i': b'High-Class'
+  }, {
+      'n': 6,
+      'q': b'Start-Class',
+      'i': b'Low-Class'
+  }, {
+      'n': 1,
+      'q': b'Start-Class',
+      'i': b'Mid-Class'
+  }, {
+      'n': 1,
+      'q': b'Start-Class',
+      'i': b'Unknown-Class'
+  }, {
+      'n': 3,
+      'q': b'Stub-Class',
+      'i': b'Low-Class'
+  }, {
+      'n': 1,
+      'q': b'Stub-Class',
+      'i': b'Unknown-Class'
+  }, {
+      'n': 2,
+      'q': b'Unassessed-Class',
+      'i': b'Unknown-Class'
+  }]
+
   sort_imp = {
-    b'High-Class': 300,
-    b'Low-Class': 100,
-    b'Mid-Class': 200,
-    b'NA-Class': 25,
-    b'NotA-Class': 21,
-    b'Top-Class': 400,
-    b'Unknown-Class': 0
+      b'High-Class': 300,
+      b'Low-Class': 100,
+      b'Mid-Class': 200,
+      b'NA-Class': 25,
+      b'NotA-Class': 21,
+      b'Top-Class': 400,
+      b'Unknown-Class': 0
   }
 
   sort_qual = {
-    b'A-Class': 425,
-    b'B-Class': 300,
-    b'Book-Class': 55,
-    b'C-Class': 225,
-    b'Category-Class': 50,
-    b'Disambig-Class': 48,
-    b'FA-Class': 500,
-    b'FL-Class': 480,
-    b'FM-Class': 460,
-    b'File-Class': 46,
-    b'GA-Class': 400,
-    b'Image-Class': 47,
-    b'List-Class': 80,
-    b'NA-Class': 25,
-    b'NotA-Class': 21,
-    b'Portal-Class': 45,
-    b'Project-Class': 44,
-    b'Redirect-Class': 43,
-    b'Start-Class': 150,
-    b'Stub-Class': 100,
-    b'Template-Class': 40,
-    b'Unassessed-Class': 0
+      b'A-Class': 425,
+      b'B-Class': 300,
+      b'Book-Class': 55,
+      b'C-Class': 225,
+      b'Category-Class': 50,
+      b'Disambig-Class': 48,
+      b'FA-Class': 500,
+      b'FL-Class': 480,
+      b'FM-Class': 460,
+      b'File-Class': 46,
+      b'GA-Class': 400,
+      b'Image-Class': 47,
+      b'List-Class': 80,
+      b'NA-Class': 25,
+      b'NotA-Class': 21,
+      b'Portal-Class': 45,
+      b'Project-Class': 44,
+      b'Redirect-Class': 43,
+      b'Start-Class': 150,
+      b'Stub-Class': 100,
+      b'Template-Class': 40,
+      b'Unassessed-Class': 0
   }
 
   def _insert_ratings(self):
     for r in self.ratings:
-      rating = Rating(
-        r_project=b'Test Project', r_namespace=0, r_article=r[0])
+      rating = Rating(r_project=b'Test Project', r_namespace=0, r_article=r[0])
       rating.r_quality = r[1]
       rating.r_quality_timestamp = GLOBAL_TIMESTAMP_WIKI
       rating.r_importance = r[2]
       rating.r_importance_timestamp = GLOBAL_TIMESTAMP_WIKI
 
       with self.wp10db.cursor() as cursor:
-        cursor.execute('INSERT INTO ' + Rating.table_name + '''
+        cursor.execute(
+            'INSERT INTO ' + Rating.table_name + '''
           (r_project, r_namespace, r_article, r_score, r_quality,
            r_quality_timestamp, r_importance, r_importance_timestamp)
           VALUES (%(r_project)s, %(r_namespace)s, %(r_article)s, %(r_score)s,
@@ -313,7 +397,8 @@ class TablesDbTest(BaseWpOneDbTest):
   def _setup_global_articles(self):
     with self.wp10db.cursor() as cursor:
       for i, scores in enumerate(self.global_articles):
-        cursor.execute('''
+        cursor.execute(
+            '''
           INSERT INTO global_articles
             (a_article, a_quality, a_importance, a_score)
           VALUES (%s, %s, %s, %s)
@@ -322,7 +407,8 @@ class TablesDbTest(BaseWpOneDbTest):
 
   def _setup_project_categories(self):
     with self.wp10db.cursor() as cursor:
-      cursor.executemany('INSERT INTO ' + Category.table_name + '''
+      cursor.executemany(
+          'INSERT INTO ' + Category.table_name + '''
           (c_project, c_type, c_rating, c_ranking, c_category, c_replacement)
         VALUES
           ('Catholicism', %(c_type)s, %(c_rating)s, %(c_ranking)s,
@@ -343,16 +429,47 @@ class TablesDbTest(BaseWpOneDbTest):
     self.assertEqual(expected, actual)
 
   def test_get_project_stats(self):
-    expected = [
-      {'n': 3, 'q': b'FA-Class', 'i': b'Top-Class', 'project': b'Test Project'},
-      {'n': 3, 'q': b'C-Class', 'i': b'Low-Class', 'project': b'Test Project'},
-      {'n': 2, 'q': b'A-Class', 'i': b'High-Class', 'project': b'Test Project'},
-      {'n': 3, 'q': b'B-Class', 'i': b'Low-Class', 'project': b'Test Project'},
-      {'n': 2, 'q': b'FL-Class', 'i': b'High-Class', 'project': b'Test Project'},
-      {'n': 3, 'q': b'GA-Class', 'i': b'Mid-Class', 'project': b'Test Project'},
-      {'n': 1, 'q': b'FL-Class', 'i': b'Top-Class', 'project': b'Test Project'},
-      {'n': 1, 'q': b'A-Class', 'i': b'Mid-Class', 'project': b'Test Project'}
-    ]
+    expected = [{
+        'n': 3,
+        'q': b'FA-Class',
+        'i': b'Top-Class',
+        'project': b'Test Project'
+    }, {
+        'n': 3,
+        'q': b'C-Class',
+        'i': b'Low-Class',
+        'project': b'Test Project'
+    }, {
+        'n': 2,
+        'q': b'A-Class',
+        'i': b'High-Class',
+        'project': b'Test Project'
+    }, {
+        'n': 3,
+        'q': b'B-Class',
+        'i': b'Low-Class',
+        'project': b'Test Project'
+    }, {
+        'n': 2,
+        'q': b'FL-Class',
+        'i': b'High-Class',
+        'project': b'Test Project'
+    }, {
+        'n': 3,
+        'q': b'GA-Class',
+        'i': b'Mid-Class',
+        'project': b'Test Project'
+    }, {
+        'n': 1,
+        'q': b'FL-Class',
+        'i': b'Top-Class',
+        'project': b'Test Project'
+    }, {
+        'n': 1,
+        'q': b'A-Class',
+        'i': b'Mid-Class',
+        'project': b'Test Project'
+    }]
     actual = tables.get_project_stats(self.wp10db, 'Test Project')
     expected = [tuple(x.items()) for x in expected]
     actual = [tuple(x.items()) for x in actual]
@@ -366,70 +483,75 @@ class TablesDbTest(BaseWpOneDbTest):
 
   def test_get_project_categories(self):
     expected = {
-      'imp_labels': {
-        b'High-Class':
-          '{{High-Class|category=Category:High-importance_Catholicism_articles}}',
-        b'Low-Class':
-          '{{Low-Class|category=Category:Low-importance_Catholicism_articles}}',
-        b'Mid-Class':
-          '{{Mid-Class|category=Category:Mid-importance_Catholicism_articles}}',
-        b'NA-Class':
-          '{{NA-Class|category=Category:NA-importance_Catholicism_articles}}',
-        b'NotA-Class': 'Other',
-        b'Top-Class':
-          '{{Top-Class|category=Category:Top-importance_Catholicism_articles}}',
-        b'Unassessed-Class': 'No-Class',
-        b'Unknown-Class':
-          '{{Unknown-Class|category=Category:Unknown-importance_Catholicism_articles}}'
-      },
-      'qual_labels': {
-        b'A-Class':
-          '{{A-Class|category=Category:A-Class_Catholicism_articles}}',
-        b'Assessed-Class':
-          '{{Assessed-Class}}',
-        b'B-Class':
-          '{{B-Class|category=Category:B-Class_Catholicism_articles}}',
-        b'Book-Class':
-          '{{Book-Class|category=Category:Book-Class_Catholicism_articles}}',
-        b'C-Class':
-          '{{C-Class|category=Category:C-Class_Catholicism_articles}}',
-        b'Category-Class':
-          '{{Category-Class|category=Category:Category-Class_Catholicism_articles}}',
-        b'Disambig-Class':
-          '{{Disambig-Class|category=Category:Disambig-Class_Catholicism_articles}}',
-        b'FA-Class':
-          '{{FA-Class|category=Category:FA-Class_Catholicism_articles}}',
-        b'FL-Class':
-          '{{FL-Class|category=Category:FL-Class_Catholicism_articles}}',
-        b'FM-Class':
-          '{{FM-Class|category=Category:FM-Class_Catholicism_articles}}',
-        b'File-Class':
-          '{{File-Class|category=Category:File-Class_Catholicism_articles}}',
-        b'GA-Class':
-          '{{GA-Class|category=Category:GA-Class_Catholicism_articles}}',
-        b'Image-Class':
-          '{{Image-Class|category=Category:Category:Image-Class Catholicism articles}}',
-        b'List-Class':
-          '{{List-Class|category=Category:List-Class_Catholicism_articles}}',
-        b'NA-Class':
-          '{{NA-Class|category=Category:NA-Class_Catholicism_articles}}',
-        b'NotA-Class': ' style="text-align: center;" | ' "'''Other'''",
-        b'Portal-Class':
-          '{{Portal-Class|category=Category:Portal-Class_Catholicism_articles}}',
-        b'Project-Class':
-          '{{Project-Class|category=Category:Project-Class_Catholicism_articles}}',
-        b'Redirect-Class':
-          '{{Redirect-Class|category=Category:Redirect-Class_Catholicism_articles}}',
-        b'Start-Class':
-          '{{Start-Class|category=Category:Start-Class_Catholicism_articles}}',
-        b'Stub-Class':
-          '{{Stub-Class|category=Category:Stub-Class_Catholicism_articles}}',
-        b'Template-Class':
-          '{{Template-Class|category=Category:Template-Class_Catholicism_articles}}',
-        b'Unassessed-Class': '{{Unassessed-Class|category=Category:Unassessed_Catholicism_articles}}',
-      },
-      'sort_imp': self.sort_imp,
-      'sort_qual': self.sort_qual,
+        'imp_labels': {
+            b'High-Class':
+                '{{High-Class|category=Category:High-importance_Catholicism_articles}}',
+            b'Low-Class':
+                '{{Low-Class|category=Category:Low-importance_Catholicism_articles}}',
+            b'Mid-Class':
+                '{{Mid-Class|category=Category:Mid-importance_Catholicism_articles}}',
+            b'NA-Class':
+                '{{NA-Class|category=Category:NA-importance_Catholicism_articles}}',
+            b'NotA-Class':
+                'Other',
+            b'Top-Class':
+                '{{Top-Class|category=Category:Top-importance_Catholicism_articles}}',
+            b'Unassessed-Class':
+                'No-Class',
+            b'Unknown-Class':
+                '{{Unknown-Class|category=Category:Unknown-importance_Catholicism_articles}}'
+        },
+        'qual_labels': {
+            b'A-Class':
+                '{{A-Class|category=Category:A-Class_Catholicism_articles}}',
+            b'Assessed-Class':
+                '{{Assessed-Class}}',
+            b'B-Class':
+                '{{B-Class|category=Category:B-Class_Catholicism_articles}}',
+            b'Book-Class':
+                '{{Book-Class|category=Category:Book-Class_Catholicism_articles}}',
+            b'C-Class':
+                '{{C-Class|category=Category:C-Class_Catholicism_articles}}',
+            b'Category-Class':
+                '{{Category-Class|category=Category:Category-Class_Catholicism_articles}}',
+            b'Disambig-Class':
+                '{{Disambig-Class|category=Category:Disambig-Class_Catholicism_articles}}',
+            b'FA-Class':
+                '{{FA-Class|category=Category:FA-Class_Catholicism_articles}}',
+            b'FL-Class':
+                '{{FL-Class|category=Category:FL-Class_Catholicism_articles}}',
+            b'FM-Class':
+                '{{FM-Class|category=Category:FM-Class_Catholicism_articles}}',
+            b'File-Class':
+                '{{File-Class|category=Category:File-Class_Catholicism_articles}}',
+            b'GA-Class':
+                '{{GA-Class|category=Category:GA-Class_Catholicism_articles}}',
+            b'Image-Class':
+                '{{Image-Class|category=Category:Category:Image-Class Catholicism articles}}',
+            b'List-Class':
+                '{{List-Class|category=Category:List-Class_Catholicism_articles}}',
+            b'NA-Class':
+                '{{NA-Class|category=Category:NA-Class_Catholicism_articles}}',
+            b'NotA-Class':
+                ' style="text-align: center;" | '
+                "'''Other'''",
+            b'Portal-Class':
+                '{{Portal-Class|category=Category:Portal-Class_Catholicism_articles}}',
+            b'Project-Class':
+                '{{Project-Class|category=Category:Project-Class_Catholicism_articles}}',
+            b'Redirect-Class':
+                '{{Redirect-Class|category=Category:Redirect-Class_Catholicism_articles}}',
+            b'Start-Class':
+                '{{Start-Class|category=Category:Start-Class_Catholicism_articles}}',
+            b'Stub-Class':
+                '{{Stub-Class|category=Category:Stub-Class_Catholicism_articles}}',
+            b'Template-Class':
+                '{{Template-Class|category=Category:Template-Class_Catholicism_articles}}',
+            b'Unassessed-Class':
+                '{{Unassessed-Class|category=Category:Unassessed_Catholicism_articles}}',
+        },
+        'sort_imp': self.sort_imp,
+        'sort_qual': self.sort_qual,
     }
     actual = tables.get_project_categories(self.wp10db, b'Catholicism')
     self.maxDiff = None
@@ -437,15 +559,30 @@ class TablesDbTest(BaseWpOneDbTest):
 
   def test_data_for_stats(self):
     expected_cols = {
-      b'High-Class': 1, b'Low-Class': 1, b'Mid-Class': 1, b'Unknown-Class': 1
+        b'High-Class': 1,
+        b'Low-Class': 1,
+        b'Mid-Class': 1,
+        b'Unknown-Class': 1
     }
-    expected_data = {b'C-Class': {b'Low-Class': 2, b'Unknown-Class': 1},
-                     b'Start-Class': {b'High-Class': 3,
-                                      b'Low-Class': 6,
-                                      b'Mid-Class': 1,
-                                      b'Unknown-Class': 1},
-                     b'Stub-Class': {b'Low-Class': 3, b'Unknown-Class': 1},
-                     b'Unassessed-Class': {b'Unknown-Class': 2}}
+    expected_data = {
+        b'C-Class': {
+            b'Low-Class': 2,
+            b'Unknown-Class': 1
+        },
+        b'Start-Class': {
+            b'High-Class': 3,
+            b'Low-Class': 6,
+            b'Mid-Class': 1,
+            b'Unknown-Class': 1
+        },
+        b'Stub-Class': {
+            b'Low-Class': 3,
+            b'Unknown-Class': 1
+        },
+        b'Unassessed-Class': {
+            b'Unknown-Class': 2
+        }
+    }
 
     actual_data, actual_cols = tables.data_for_stats(self.stats)
     actual_data_dict = dict((k, dict(v)) for k, v in actual_data.items())
@@ -456,28 +593,37 @@ class TablesDbTest(BaseWpOneDbTest):
   def test_generate_table_data_removes_cols(self):
     missing_mid = dict(self.sort_imp)
     del missing_mid[b'Mid-Class']
-    actual = tables.generate_table_data(self.stats, {
-      'sort_imp': missing_mid, 'sort_qual': {},
-      'imp_labels': {}, 'qual_labels': {}
-    })
+    actual = tables.generate_table_data(
+        self.stats, {
+            'sort_imp': missing_mid,
+            'sort_qual': {},
+            'imp_labels': {},
+            'qual_labels': {}
+        })
 
     self.assertTrue(b'Mid-Class' not in actual['ordered_cols'])
 
   def test_generate_table_data_removes_rows(self):
     missing_portal = dict(self.sort_qual)
     del missing_portal[b'Portal-Class']
-    actual = tables.generate_table_data(self.stats, {
-      'sort_imp': missing_portal, 'sort_qual': {},
-      'imp_labels': {}, 'qual_labels': {}
-    }, {'project_display': 'Test Project'})
+    actual = tables.generate_table_data(
+        self.stats, {
+            'sort_imp': missing_portal,
+            'sort_qual': {},
+            'imp_labels': {},
+            'qual_labels': {}
+        }, {'project_display': 'Test Project'})
 
     self.assertTrue(b'Portal-Class' not in actual['ordered_rows'])
 
   def test_generate_table_data_adds_assessed_when_unassessed(self):
-    actual = tables.generate_table_data(self.stats, {
-      'sort_imp': self.sort_imp, 'sort_qual': self.sort_qual,
-      'imp_labels': {}, 'qual_labels': {}
-    })
+    actual = tables.generate_table_data(
+        self.stats, {
+            'sort_imp': self.sort_imp,
+            'sort_qual': self.sort_qual,
+            'imp_labels': {},
+            'qual_labels': {}
+        })
 
     self.assertTrue(b'Unassessed-Class' in actual['ordered_rows'])
     self.assertTrue(b'Assessed-Class' in actual['ordered_rows'])
@@ -489,36 +635,42 @@ class TablesDbTest(BaseWpOneDbTest):
   def test_generate_table_data_adds_assessed_when_no_unassessed(self):
     missing_unassessed = dict(self.sort_qual)
     del missing_unassessed[b'Unassessed-Class']
-    actual = tables.generate_table_data(self.stats, {
-      'sort_imp': self.sort_imp, 'sort_qual': missing_unassessed,
-      'imp_labels': {}, 'qual_labels': {}
-    })
+    actual = tables.generate_table_data(
+        self.stats, {
+            'sort_imp': self.sort_imp,
+            'sort_qual': missing_unassessed,
+            'imp_labels': {},
+            'qual_labels': {}
+        })
 
     self.assertFalse(b'Unassessed-Class' in actual['ordered_rows'])
     self.assertTrue(b'Assessed-Class' in actual['ordered_rows'])
     self.assertEqual(
-      len(actual['ordered_rows']) - 1,
-      actual['ordered_rows'].index(b'Assessed-Class'))
+        len(actual['ordered_rows']) - 1,
+        actual['ordered_rows'].index(b'Assessed-Class'))
 
   def test_generate_table_data_totals(self):
     expected_col_totals = {
-      b'High-Class': 3,
-      b'Low-Class': 11,
-      b'Mid-Class': 1,
-      b'Unknown-Class': 5
+        b'High-Class': 3,
+        b'Low-Class': 11,
+        b'Mid-Class': 1,
+        b'Unknown-Class': 5
     }
     expected_row_totals = {
-      b'Assessed-Class': 18,
-      b'C-Class': 3,
-      b'Start-Class': 11,
-      b'Stub-Class': 4,
-      b'Unassessed-Class': 2
+        b'Assessed-Class': 18,
+        b'C-Class': 3,
+        b'Start-Class': 11,
+        b'Stub-Class': 4,
+        b'Unassessed-Class': 2
     }
 
-    actual = tables.generate_table_data(self.stats, {
-      'sort_imp': self.sort_imp, 'sort_qual': self.sort_qual,
-      'imp_labels': {}, 'qual_labels': {}
-    })
+    actual = tables.generate_table_data(
+        self.stats, {
+            'sort_imp': self.sort_imp,
+            'sort_qual': self.sort_qual,
+            'imp_labels': {},
+            'qual_labels': {}
+        })
 
     self.assertEqual(20, actual['total'])
     self.assertEqual(expected_col_totals, actual['col_totals'])
@@ -526,33 +678,39 @@ class TablesDbTest(BaseWpOneDbTest):
 
   def test_generate_table_data_ordered_cols(self):
     expected = [b'High-Class', b'Mid-Class', b'Low-Class', b'Unknown-Class']
-    actual = tables.generate_table_data(self.stats, {
-      'sort_imp': self.sort_imp, 'sort_qual': self.sort_qual,
-      'imp_labels': {}, 'qual_labels': {}
-    })
+    actual = tables.generate_table_data(
+        self.stats, {
+            'sort_imp': self.sort_imp,
+            'sort_qual': self.sort_qual,
+            'imp_labels': {},
+            'qual_labels': {}
+        })
     self.assertEqual(expected, actual['ordered_cols'])
 
   def test_generate_table_data_ordered_rows(self):
     expected = [
-      b'C-Class',
-      b'Start-Class',
-      b'Stub-Class',
-      b'Assessed-Class',
-      b'Unassessed-Class'
+        b'C-Class', b'Start-Class', b'Stub-Class', b'Assessed-Class',
+        b'Unassessed-Class'
     ]
-    actual = tables.generate_table_data(self.stats, {
-      'sort_imp': self.sort_imp, 'sort_qual': self.sort_qual,
-      'imp_labels': {}, 'qual_labels': {}
-    })
+    actual = tables.generate_table_data(
+        self.stats, {
+            'sort_imp': self.sort_imp,
+            'sort_qual': self.sort_qual,
+            'imp_labels': {},
+            'qual_labels': {}
+        })
     self.assertEqual(expected, actual['ordered_rows'])
 
   def test_generate_table_data_labels(self):
     expected_imp_labels = {'foo': 'bar'}
     expected_qual_labels = {'baz': 'bang'}
-    actual = tables.generate_table_data(self.stats, {
-      'sort_imp': self.sort_imp, 'sort_qual': self.sort_qual,
-      'imp_labels': expected_imp_labels, 'qual_labels': expected_qual_labels
-    })
+    actual = tables.generate_table_data(
+        self.stats, {
+            'sort_imp': self.sort_imp,
+            'sort_qual': self.sort_qual,
+            'imp_labels': expected_imp_labels,
+            'qual_labels': expected_qual_labels
+        })
 
     self.assertEqual(expected_imp_labels, actual['col_labels'])
     self.assertEqual(expected_qual_labels, actual['row_labels'])
@@ -560,21 +718,23 @@ class TablesDbTest(BaseWpOneDbTest):
   def test_generate_table_data_table_overrides(self):
     expected_overrides = {'foo': 'bar', 42: 'answer', 'baz': 'bang'}
     actual = tables.generate_table_data(self.stats, {
-      'sort_imp': self.sort_imp, 'sort_qual': self.sort_qual,
-      'imp_labels': {}, 'qual_labels': {}
-    }, table_overrides=expected_overrides)
+        'sort_imp': self.sort_imp,
+        'sort_qual': self.sort_qual,
+        'imp_labels': {},
+        'qual_labels': {}
+    },
+                                        table_overrides=expected_overrides)
     for k, v in expected_overrides.items():
       self.assertEqual(v, actual[k])
 
   def test_generate_project_table_data(self):
     actual = tables.generate_project_table_data(self.wp10db, b'Catholicism')
-    self.assertEqual(
-      'Catholicism pages by quality', actual['title'])
+    self.assertEqual('Catholicism pages by quality', actual['title'])
 
   def test_generate_global_table_data(self):
     actual = tables.generate_global_table_data(self.wp10db)
-    self.assertEqual(
-      'All rated articles by quality and importance', actual['title'])
+    self.assertEqual('All rated articles by quality and importance',
+                     actual['title'])
 
   @patch('wp1.tables.api')
   @patch('wp1.tables.wp10_connect')

--- a/wp1/wiki_db.py
+++ b/wp1/wiki_db.py
@@ -8,10 +8,10 @@ try:
 
   def connect():
     kwargs = {
-      'charset': None,
-      'use_unicode': False,
-      'cursorclass': pymysql.cursors.SSDictCursor,
-      **WIKI_CREDS
+        'charset': None,
+        'use_unicode': False,
+        'cursorclass': pymysql.cursors.SSDictCursor,
+        **WIKI_CREDS
     }
     return pymysql.connect(**kwargs)
 

--- a/wp1/wp10_db.py
+++ b/wp1/wp10_db.py
@@ -8,10 +8,10 @@ try:
 
   def connect():
     kwargs = {
-      'charset': None,
-      'use_unicode': False,
-      'cursorclass': pymysql.cursors.DictCursor,
-      **WP10_CREDS
+        'charset': None,
+        'use_unicode': False,
+        'cursorclass': pymysql.cursors.DictCursor,
+        **WP10_CREDS
     }
     return pymysql.connect(**kwargs)
 except ImportError:
@@ -19,4 +19,3 @@ except ImportError:
   # to satisfy imports.
   def connect():
     pass
-


### PR DESCRIPTION
See https://github.com/google/yapf

I've configured it slightly for Google style (80 width) but with 2 spaces indent, which helps save width.

@kelson42 let me know what you think! We can add a pre-commit git hook for this if we like it. Personally, I think it's pretty good, except for the SQL queries, which probably need some love anyways.